### PR TITLE
[PREVIEW · NO MERGEAR] Prototipo: comparación entre elecciones (Fase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/bmad-output/
 scripts/__pycache__/
 __pycache__/
 *.pyc
+
+# Brainstorm visual companion (superpowers)
+.superpowers/

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2097,7 +2097,11 @@ const unsubSelection = $selection.subscribe((s) => {
   gnivel.value = esNivel(s.gnivel) ? s.gnivel : 'lema';
   syncNivelesDisponibles();
   applySelection(s.zona);
-  if (s.seleccion.length > 0) {
+  if (comparacionActiva.value) {
+    // Comparación activa: clickear una zona NO debe re-renderizar la vista base (eso causaba un
+    // flash del render común por un frame). Mantenemos el coloreo de comparación intacto.
+    renderComparacionFill();
+  } else if (s.seleccion.length > 0) {
     void applySeleccion(); // Epic 10: coloreo por selección múltiple de hojas (usa gnivel)
   } else if (gnivel.value !== 'lema') {
     void aplicarGanadorAbsolutoPorNivel(); // sin selección, sub-nivel → ganador absoluto del nivel (base = ganador)

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2197,7 +2197,14 @@ onMounted(async () => {
         source: 'zonas',
         paint: {
           'line-color': '#f97316',
-          'line-width': ['case', ['boolean', ['feature-state', 'vsChanged'], false], 3, 0],
+          // Grueso + punteado para que se distinga de los bordes negros de base y resalte sobre
+          // los rellenos de bandera. Ancho responsivo al zoom (zoom debe ser input top-level del
+          // interpolate; el case por feature-state va en los STOPS, no envolviendo al zoom).
+          'line-width': ['interpolate', ['linear'], ['zoom'],
+            4, ['case', ['boolean', ['feature-state', 'vsChanged'], false], 4, 0],
+            9, ['case', ['boolean', ['feature-state', 'vsChanged'], false], 7, 0]],
+          'line-dasharray': [2, 1.1],
+          'line-opacity': ['case', ['boolean', ['feature-state', 'vsChanged'], false], 1, 0],
         },
       });
       m.addLayer({

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -9,7 +9,7 @@
  * entre departamentos. En `astro:after-swap` recarga datos sin re-inicializar MapLibre
  * (NFR1 anti-jank). La URL es la fuente de verdad; nanostores espejan.
  */
-import { onMounted, onUnmounted, ref, shallowRef } from 'vue';
+import { onMounted, onUnmounted, ref, shallowRef, computed } from 'vue';
 import type { Map as MlMap, Marker as MlMarker, LngLatBoundsLike, GeoJSONSource } from 'maplibre-gl';
 import type { Feature, FeatureCollection, Polygon, MultiPolygon, Position } from 'geojson';
 import type { Topology, GeometryCollection } from 'topojson-specification';
@@ -164,7 +164,10 @@ let ciudadesGrandesSet = new Set<string>();
 let intensidadActive = false;
 // Comparación dual (Story 4.3): ganador por zona de la elección de comparación.
 let vsWinnersMap = new Map<string, string>(); // normalizedGeoId → nombre del ganador en elección vs
+let vsZonaPct = new Map<string, Map<string, number>>(); // normGeoId → sigla → % (0..1) en la elección vs (delta Fase 2)
 let unsubComparison: (() => void) | null = null;
+/** Expresión base de opacidad del relleno (flags transparentan su zona). Reusada para restaurar tras el delta. */
+const BASE_FILL_OPACITY = ['case', ['!=', ['get', 'flagPattern'], null], 0, 0.85];
 // True cuando el nivel activo usa geometría Point (circuito) en lugar de Polygon (Story 6.3).
 let isPointNivel = false;
 // Unsub del overlay de circuitos.
@@ -197,6 +200,18 @@ const gnivel = ref<Nivel>('lema');
 const nivelesDisponibles = ref<Nivel[]>(['lema']);
 /** Comparación entre elecciones activa (overlay ?vs= aplicado) → muestra leyenda + nota del borde naranja. */
 const comparacionActiva = ref(false);
+/** Sub-modo de comparación: 'ganador' (flip, borde naranja) | 'delta' (Δ% de un partido, escala divergente). */
+const cmpModo = ref<'ganador' | 'delta'>('ganador');
+/** Sigla del partido cuyo Δ% se colorea en modo delta. Default = ganador de la elección base. */
+const cmpDeltaSigla = ref('');
+/** Clamp del gradiente divergente del delta (±15 puntos porcentuales; deltas reales son chicos). */
+const DELTA_CLAMP = 0.15;
+/** Partidos seleccionables para el delta (siglas presentes en la base, dedup, con color). */
+const siglasComparables = computed(() => {
+  const seen = new Map<string, { sigla: string; nombre: string; color: string }>();
+  for (const e of resultadoGlobal.value) if (!seen.has(e.sigla)) seen.set(e.sigla, { sigla: e.sigla, nombre: e.nombre, color: e.color });
+  return [...seen.values()];
+});
 // hojaId → metadata del catálogo (del catalogo.json). Null = aún no cargado.
 // Ampliado (coloreo-por-nivel): incluye precandidatoId/sublemaId para agrupar el ganador a cualquier nivel.
 let catalogoOpcMeta: Map<string, {
@@ -1556,6 +1571,8 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
     vsWinnersMap = new Map();
     // vsSiglaMap: geoId normalizado → sigla canónica del ganador en la elección vs
     const vsSiglaMap = new Map<string, string>();
+    // vsZonaPct: geoId normalizado → sigla → % (0..1) en la elección vs (para el delta Fase 2).
+    vsZonaPct = new Map();
     for (const z of votes.zonas) {
       if (z.porOpcion.length > 0) {
         const vsNombre = vsNombrePorOpcion.get(z.ganadorOpcionId) ?? z.ganadorOpcionId;
@@ -1563,6 +1580,18 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
         // Sigla: desde la tabla de equiv si existe, sino desde resolveParty
         const sigla = siglaFromBId.get(z.ganadorOpcionId) ?? resolveParty(vsNombre).sigla;
         vsSiglaMap.set(norm(z.geoId), sigla);
+        // % por sigla en esta zona (delta). Agrega por sigla canónica; share sobre válidos.
+        if (z.validos > 0) {
+          const porSigla = new Map<string, number>();
+          for (const o of z.porOpcion) {
+            const nombre = vsNombrePorOpcion.get(o.opcionId) ?? o.opcionId;
+            const s = siglaFromBId.get(o.opcionId) ?? resolveParty(nombre).sigla;
+            porSigla.set(s, (porSigla.get(s) ?? 0) + o.votos);
+          }
+          const pctMap = new Map<string, number>();
+          for (const [s, v] of porSigla) pctMap.set(s, v / z.validos);
+          vsZonaPct.set(norm(z.geoId), pctMap);
+        }
       }
     }
 
@@ -1595,10 +1624,77 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
       return vsSiglas.has(entrySigla) ? entry : { ...entry, nombre: `${entry.nombre} (solo ${year})` };
     });
     comparacionActiva.value = true; // overlay aplicado → leyenda + nota del borde naranja
+    if (!cmpDeltaSigla.value || !siglasComparables.value.some((s) => s.sigla === cmpDeltaSigla.value)) {
+      cmpDeltaSigla.value = resultadoGlobal.value[0]?.sigla ?? ''; // default = ganador de la base
+    }
+    renderComparacionFill(); // aplica relleno según el sub-modo (ganador | delta)
   } catch {
     // Degradación silenciosa: si no hay datos de comparación, el mapa sigue normal.
   }
 }
+
+/** % (0..1) de una sigla en una zona de la elección BASE (sobre válidos). null si no hay datos. */
+function basePctSiglaEnZona(key: string, sigla: string): number | null {
+  const validos = zonasValidos.get(key) ?? 0;
+  if (validos <= 0) return null;
+  const vm = zonasVotos.get(key);
+  if (!vm) return null;
+  let s = 0;
+  for (const [oid, v] of vm) if (resolveParty(opcNombreMap.get(oid) ?? oid, activeEleccion).sigla === sigla) s += v;
+  return s / validos;
+}
+
+/**
+ * Aplica el relleno del mapa según el sub-modo de comparación (Fase 2).
+ * - 'ganador': relleno base (colores de partido + banderas), con el borde naranja del flip.
+ * - 'delta':   relleno divergente por Δ% (base − vs) del partido `cmpDeltaSigla`; zonas sin dato
+ *              comparable van GRISES (nunca delta-contra-cero → evita falsos extremos).
+ */
+function renderComparacionFill(): void {
+  const m = map.value;
+  const fc = fcRef.value;
+  if (!m || !fc) return;
+  if (cmpModo.value !== 'delta' || !cmpDeltaSigla.value) {
+    for (const f of fc.features) {
+      const name = String((f.properties as { name: string }).name);
+      m.setFeatureState({ source: 'zonas', id: name }, { delta: 0, deltaNA: false });
+    }
+    m.setPaintProperty('zonas-fill', 'fill-color', ['get', 'color']);
+    m.setPaintProperty('zonas-fill', 'fill-opacity', BASE_FILL_OPACITY);
+    setPatternVisible(true);
+    if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'visible'); // borde naranja del flip
+    return;
+  }
+  const sigla = cmpDeltaSigla.value;
+  for (const f of fc.features) {
+    const name = String((f.properties as { name: string }).name);
+    const key = norm(name);
+    const basePct = basePctSiglaEnZona(key, sigla);
+    const vsPct = vsZonaPct.get(key)?.get(sigla);
+    if (basePct === null || vsPct === undefined) {
+      m.setFeatureState({ source: 'zonas', id: name }, { deltaNA: true, delta: 0 }); // sin dato comparable → gris
+      continue;
+    }
+    const d = Math.max(-DELTA_CLAMP, Math.min(DELTA_CLAMP, basePct - vsPct));
+    m.setFeatureState({ source: 'zonas', id: name }, { delta: d, deltaNA: false });
+  }
+  // Relleno sólido (sin banderas) + escala divergente rojo(cae) ↔ blanco ↔ verde(sube).
+  // En delta ocultamos el borde naranja del flip → el mapa habla solo de magnitud.
+  setPatternVisible(false);
+  if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'none');
+  m.setPaintProperty('zonas-fill', 'fill-opacity', 0.85);
+  m.setPaintProperty('zonas-fill', 'fill-color', [
+    'case',
+    ['boolean', ['feature-state', 'deltaNA'], false], '#d4d4d8',
+    ['interpolate', ['linear'], ['to-number', ['feature-state', 'delta'], 0],
+      -0.15, '#b91c1c', -0.05, '#fca5a5', 0, '#f4f4f5', 0.05, '#86efac', 0.15, '#15803d'],
+  ]);
+}
+
+/** Cambia el sub-modo de comparación (ganador | delta) y re-renderiza el relleno. */
+function setCmpModo(modo: 'ganador' | 'delta'): void { cmpModo.value = modo; renderComparacionFill(); }
+/** Cambia el partido seguido por el delta y re-renderiza. */
+function setCmpDeltaSigla(sigla: string): void { cmpDeltaSigla.value = sigla; renderComparacionFill(); }
 
 /** Limpia el overlay de comparación: restaura feature-states y leyenda original (Story 4.3). */
 function clearComparisonOverlay(): void {
@@ -1607,11 +1703,18 @@ function clearComparisonOverlay(): void {
   if (!m || !fc) return;
   for (const f of fc.features) {
     const name = String((f.properties as { name: string }).name);
-    m.setFeatureState({ source: 'zonas', id: name }, { vsChanged: false });
+    m.setFeatureState({ source: 'zonas', id: name }, { vsChanged: false, deltaNA: false, delta: 0 });
   }
+  // Si el delta había cambiado el relleno/opacidad, restaurar la vista base.
+  m.setPaintProperty('zonas-fill', 'fill-color', ['get', 'color']);
+  m.setPaintProperty('zonas-fill', 'fill-opacity', BASE_FILL_OPACITY);
+  setPatternVisible(true);
+  if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'visible');
   vsWinnersMap = new Map();
+  vsZonaPct = new Map();
   legend.value = origLegend;
   comparacionActiva.value = false;
+  cmpModo.value = 'ganador';
 }
 
 /**
@@ -2229,7 +2332,31 @@ onUnmounted(() => {
     <MapLegend
       v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema' || comparacionActiva"
       :entradas="legend" :sin-datos="sinDatos" :votos-sin-ubicacion="votosSinUbicacion" :zonas-sin-ubicacion="zonasSinUbicacion"
-      :comparacion-nota="comparacionActiva ? 'Borde naranja: zonas donde cambió el partido ganador entre las dos elecciones.' : null" />
+      :comparacion-nota="comparacionActiva && cmpModo === 'ganador' ? 'Borde naranja: zonas donde cambió el partido ganador entre las dos elecciones.' : null" />
+
+    <!-- Comparación entre elecciones (Fase 2): cómo ver el contraste. Va DEBAJO del mapa (junto a la
+         leyenda) para no re-saturar arriba. 'Cambió ganador' = flip (borde naranja); 'Δ %' = magnitud
+         del cambio de un partido (escala divergente). El selector de partido vive acá, no arriba. -->
+    <div v-if="comparacionActiva" class="cmp-view">
+      <div class="cmp-view__modos" role="group" aria-label="Modo de comparación">
+        <button type="button" class="cmp-view__btn" :class="{ 'cmp-view__btn--activo': cmpModo === 'ganador' }"
+          :aria-pressed="cmpModo === 'ganador'" @click="setCmpModo('ganador')">Cambió ganador</button>
+        <button type="button" class="cmp-view__btn" :class="{ 'cmp-view__btn--activo': cmpModo === 'delta' }"
+          :aria-pressed="cmpModo === 'delta'" @click="setCmpModo('delta')">Δ % de un partido</button>
+      </div>
+      <div v-if="cmpModo === 'delta'" class="cmp-view__delta">
+        <label class="cmp-view__lbl">Partido:
+          <select class="cmp-view__sel" :value="cmpDeltaSigla"
+            @change="setCmpDeltaSigla(($event.target as HTMLSelectElement).value)" aria-label="Partido para el delta">
+            <option v-for="s in siglasComparables" :key="s.sigla" :value="s.sigla">{{ s.sigla }} — {{ s.nombre }}</option>
+          </select>
+        </label>
+        <div class="cmp-view__grad" aria-hidden="true">
+          <span>−15pp</span><span class="cmp-view__gradbar"></span><span>+15pp</span>
+        </div>
+        <p class="cmp-view__cap">Δ <strong>{{ cmpDeltaSigla }}</strong> = esta elección − la otra · <span class="cmp-view__rojo">rojo cayó</span> / <span class="cmp-view__verde">verde subió</span> · gris = sin dato comparable. Escala recortada a ±15 puntos.</p>
+      </div>
+    </div>
 
     <!-- Toggle Ganador / Intensidad — sólo visible cuando hay opción activa (Story 2.3) -->
     <div v-if="opcionActiva" class="vista-toggle" role="group" aria-label="Tipo de vista del mapa">
@@ -2378,5 +2505,44 @@ onUnmounted(() => {
   font-weight: 700;
   border-color: #1d4ed8;
 }
+
+/* Comparación Fase 2: controles de "cómo ver el contraste", debajo del mapa (no re-satura arriba). */
+.cmp-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+.cmp-view__modos { display: flex; gap: 0; }
+.cmp-view__btn {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  min-height: 36px;
+}
+.cmp-view__btn:first-child { border-radius: 0.25rem 0 0 0.25rem; }
+.cmp-view__btn:last-child { border-radius: 0 0.25rem 0.25rem 0; border-left: none; }
+.cmp-view__btn--activo { background: #1d4ed8; color: #fff; font-weight: 700; border-color: #1d4ed8; }
+.cmp-view__delta { display: flex; flex-direction: column; gap: 0.375rem; }
+.cmp-view__lbl { font-size: 0.75rem; color: var(--color-ink-soft); display: flex; align-items: center; gap: 0.375rem; }
+.cmp-view__sel {
+  font-size: 0.75rem; padding: 0.2rem 0.4rem;
+  border: 1px solid var(--color-border-strong); border-radius: 0.25rem;
+  background: var(--color-paper); color: var(--color-ink); cursor: pointer;
+}
+.cmp-view__grad { display: flex; align-items: center; gap: 0.5rem; font-size: 0.6875rem; color: var(--color-ink-muted); }
+.cmp-view__gradbar {
+  flex: 1; height: 0.625rem; border-radius: 0.3125rem;
+  background: linear-gradient(90deg, #b91c1c, #fca5a5, #f4f4f5, #86efac, #15803d);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+.cmp-view__cap { margin: 0; font-size: 0.6875rem; line-height: 1.4; color: var(--color-ink-faint); }
+.cmp-view__rojo { color: #b91c1c; font-weight: 600; }
+.cmp-view__verde { color: #15803d; font-weight: 600; }
 
 </style>

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -195,6 +195,8 @@ const coloreoMode = ref<'ganador' | 'share' | 'heatmap'>('heatmap');
 const gnivel = ref<Nivel>('lema');
 /** Niveles agrupables de la contienda activa (deriva el selector `gnivel`). */
 const nivelesDisponibles = ref<Nivel[]>(['lema']);
+/** Comparación entre elecciones activa (overlay ?vs= aplicado) → muestra leyenda + nota del borde naranja. */
+const comparacionActiva = ref(false);
 // hojaId → metadata del catálogo (del catalogo.json). Null = aún no cargado.
 // Ampliado (coloreo-por-nivel): incluye precandidatoId/sublemaId para agrupar el ganador a cualquier nivel.
 let catalogoOpcMeta: Map<string, {
@@ -1509,6 +1511,7 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
   const m = map.value;
   const fc = fcRef.value;
   if (!m || !fc || status.value !== 'listo') return;
+  comparacionActiva.value = false; // se confirma al final si el overlay aplica
   try {
     const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -1591,6 +1594,7 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
       const entrySigla = resolveParty(entry.nombre).sigla;
       return vsSiglas.has(entrySigla) ? entry : { ...entry, nombre: `${entry.nombre} (solo ${year})` };
     });
+    comparacionActiva.value = true; // overlay aplicado → leyenda + nota del borde naranja
   } catch {
     // Degradación silenciosa: si no hay datos de comparación, el mapa sigue normal.
   }
@@ -1607,6 +1611,7 @@ function clearComparisonOverlay(): void {
   }
   vsWinnersMap = new Map();
   legend.value = origLegend;
+  comparacionActiva.value = false;
 }
 
 /**
@@ -2222,8 +2227,9 @@ onUnmounted(() => {
          coloreo y del RESULTADO. Solo aporta en modos selección/filtro/intensidad (escala)
          o si hay nota de votos sin ubicación; en el modo ganador base duplica a RESULTADO. -->
     <MapLegend
-      v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema'"
-      :entradas="legend" :sin-datos="sinDatos" :votos-sin-ubicacion="votosSinUbicacion" :zonas-sin-ubicacion="zonasSinUbicacion" />
+      v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema' || comparacionActiva"
+      :entradas="legend" :sin-datos="sinDatos" :votos-sin-ubicacion="votosSinUbicacion" :zonas-sin-ubicacion="zonasSinUbicacion"
+      :comparacion-nota="comparacionActiva ? 'Borde naranja: zonas donde cambió el partido ganador entre las dos elecciones.' : null" />
 
     <!-- Toggle Ganador / Intensidad — sólo visible cuando hay opción activa (Story 2.3) -->
     <div v-if="opcionActiva" class="vista-toggle" role="group" aria-label="Tipo de vista del mapa">

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -166,6 +166,7 @@ let intensidadActive = false;
 let vsWinnersMap = new Map<string, string>(); // normalizedGeoId → nombre del ganador en elección vs
 let vsZonaPct = new Map<string, Map<string, number>>(); // normGeoId → sigla → % (0..1) en la elección vs (delta Fase 2)
 let unsubComparison: (() => void) | null = null;
+let lastCmpKey: string | null = null; // última comparación aplicada (vs|a|b); evita re-aplicar (refetch) en cada commit
 /** Expresión base de opacidad del relleno (flags transparentan su zona). Reusada para restaurar tras el delta. */
 const BASE_FILL_OPACITY = ['case', ['!=', ['get', 'flagPattern'], null], 0, 0.85];
 // True cuando el nivel activo usa geometría Point (circuito) en lugar de Polygon (Story 6.3).
@@ -1862,6 +1863,7 @@ async function reloadData(eleccion: string, departamento: string, nivel: string)
     } else if (cmp.vs && cmp.vs !== eleccion) {
       void applyComparisonOverlay(cmp.vs, eleccion, departamento, nivel);
     }
+    lastCmpKey = `${cmp.vs ?? ''}|${cmp.a ?? ''}|${cmp.b ?? ''}`; // aplicado directo → que el subscribe no repita
     // Recargar overlay de circuitos si sigue activo.
     if ($circuito.get()) void loadCircuitoOverlay(eleccion, departamento);
   } catch (err) {
@@ -2138,6 +2140,11 @@ onMounted(async () => {
   // hydrateStores (llamado en after-swap y bindToLocation) ya actualiza este store.
   unsubComparison = $comparison.subscribe((cmp) => {
     if (!map.value || status.value !== 'listo') return;
+    // Un commit({zona}) (click) re-emite $comparison con el MISMO vs → no re-aplicar (eso reseteaba
+    // comparacionActiva + refetch async ~900ms = flash del render común). Solo actuar si cambió.
+    const key = `${cmp.vs ?? ''}|${cmp.a ?? ''}|${cmp.b ?? ''}`;
+    if (key === lastCmpKey) return;
+    lastCmpKey = key;
     if (cmp.a && cmp.b) {
       applyDualOpcionView(cmp.a, cmp.b);
     } else if (cmp.vs && cmp.vs !== activeEleccion) {
@@ -2298,6 +2305,8 @@ onMounted(async () => {
       } else if (initCmp.vs && initCmp.vs !== props.eleccion) {
         void applyComparisonOverlay(initCmp.vs, props.eleccion, props.departamento, activeNivel);
       }
+      lastCmpKey = `${initCmp.vs ?? ''}|${initCmp.a ?? ''}|${initCmp.b ?? ''}`; // aplicado directo en init → que el subscribe no repita
+
       // Activar overlay de circuitos si la URL ya traía ?circ=1.
       if ($circuito.get()) void loadCircuitoOverlay(props.eleccion, props.departamento);
       // Fix (Epic 15): en algunas rutas (p. ej. la vista nacional, con menos contenido sobre el

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -721,6 +721,7 @@ function drawFlagOverlay(m: MlMap): void {
   if (!flagCtx || !flagCanvas) return;
   syncFlagCanvasSize(m);
   flagCtx.clearRect(0, 0, flagCanvas.width, flagCanvas.height);
+  flagCtx.globalAlpha = 1.0; // baseline; la atenuación de flip se aplica por-bandera en Pasada 1
 
   const dpr = window.devicePixelRatio || 1;
 
@@ -760,12 +761,17 @@ function drawFlagOverlay(m: MlMap): void {
       }
     };
 
+    // Comparación modo "cambió ganador": atenuar las banderas de las zonas que NO cambiaron
+    // → las que flipearon quedan a full y saltan. Mantiene TODAS las banderas visibles.
+    const flipDim = comparacionActiva.value && cmpModo.value === 'ganador';
     // Pasada 1: flags recortados a cada polígono completo (un solo drawImage por barrio)
     for (const f of feats) {
       const props = f.properties as Record<string, unknown>;
       if (!props.flagPattern || !props.hasData) continue;
       const img = flagImgs[props.flagPattern as string];
       if (!img) continue;
+      const fname = String(props.name ?? '');
+      const dimmed = flipDim && !m.getFeatureState({ source: 'zonas', id: fname })?.vsChanged;
       const bbox = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
       tracePath(f, bbox);
       if (!Number.isFinite(bbox.minX)) continue;
@@ -783,7 +789,7 @@ function drawFlagOverlay(m: MlMap): void {
       const flagAspect = img.naturalWidth / img.naturalHeight;
       let dw = bw, dh = bw / flagAspect;
       if (dh < bh) { dh = bh; dw = bh * flagAspect; }
-      flagCtx.globalAlpha = 1.0;
+      flagCtx.globalAlpha = dimmed ? 0.3 : 1.0;
       flagCtx.drawImage(img, minX + (bw - dw) / 2, minY + (bh - dh) / 2, dw, dh);
       flagCtx.restore();
     }
@@ -791,6 +797,7 @@ function drawFlagOverlay(m: MlMap): void {
     // Pasada 2: bordes encima de todos los flags + highlight de zona seleccionada
     const selectedGeoId = selected.value?.geoId ?? null;
     flagCtx.lineJoin = 'round';
+    flagCtx.globalAlpha = 1.0; // los bordes nunca se atenúan (Pasada 1 pudo dejar alpha < 1)
     for (const f of feats) {
       const fid = String((f.properties as { name?: string }).name ?? '');
       tracePath(f);
@@ -1655,18 +1662,23 @@ function renderComparacionFill(): void {
   const fc = fcRef.value;
   if (!m || !fc) return;
   if (cmpModo.value !== 'delta' || !cmpDeltaSigla.value) {
-    // 'ganador' (flip) por REALCE-POR-CONTRASTE (reemplaza el contorno naranja, que no leía):
-    // las zonas que CAMBIARON de ganador quedan a todo color; las que se mantuvieron, atenuadas
-    // (fantasma). Técnica de cartografía electoral estándar — las que flipearon saltan solas.
+    // 'ganador' (flip) por REALCE-POR-CONTRASTE, MANTENIENDO LAS BANDERAS: las zonas que cambiaron
+    // de ganador quedan a full; las que se mantuvieron, atenuadas. Las banderas (canvas) se atenúan
+    // por alpha en drawFlagOverlay; los rellenos sólidos (sin bandera) por fill-opacity acá.
     for (const f of fc.features) {
       const name = String((f.properties as { name: string }).name);
       m.setFeatureState({ source: 'zonas', id: name }, { delta: 0, deltaNA: false });
     }
-    setPatternVisible(false); // colores sólidos (sin banderas) para que la atenuación lea limpia
+    setPatternVisible(true); // banderas SIEMPRE visibles
     if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'none'); // contorno abandonado
     m.setPaintProperty('zonas-fill', 'fill-color', ['get', 'color']);
-    m.setPaintProperty('zonas-fill', 'fill-opacity',
-      ['case', ['boolean', ['feature-state', 'vsChanged'], false], 0.92, 0.14]);
+    m.setPaintProperty('zonas-fill', 'fill-opacity', [
+      'case',
+      ['!=', ['get', 'flagPattern'], null], 0,                              // con bandera → la dibuja el canvas
+      ['boolean', ['feature-state', 'vsChanged'], false], 0.85,             // sin bandera, cambió → full
+      0.22,                                                                 // sin bandera, se mantuvo → atenuado
+    ]);
+    drawFlagOverlay(m); // redibuja banderas con la atenuación de las que no cambiaron
     return;
   }
   const sigla = cmpDeltaSigla.value;
@@ -1719,6 +1731,7 @@ function clearComparisonOverlay(): void {
   legend.value = origLegend;
   comparacionActiva.value = false;
   cmpModo.value = 'ganador';
+  drawFlagOverlay(m); // redibuja banderas a full (sin atenuación de flip)
 }
 
 /**

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -1655,14 +1655,18 @@ function renderComparacionFill(): void {
   const fc = fcRef.value;
   if (!m || !fc) return;
   if (cmpModo.value !== 'delta' || !cmpDeltaSigla.value) {
+    // 'ganador' (flip) por REALCE-POR-CONTRASTE (reemplaza el contorno naranja, que no leía):
+    // las zonas que CAMBIARON de ganador quedan a todo color; las que se mantuvieron, atenuadas
+    // (fantasma). Técnica de cartografía electoral estándar — las que flipearon saltan solas.
     for (const f of fc.features) {
       const name = String((f.properties as { name: string }).name);
       m.setFeatureState({ source: 'zonas', id: name }, { delta: 0, deltaNA: false });
     }
+    setPatternVisible(false); // colores sólidos (sin banderas) para que la atenuación lea limpia
+    if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'none'); // contorno abandonado
     m.setPaintProperty('zonas-fill', 'fill-color', ['get', 'color']);
-    m.setPaintProperty('zonas-fill', 'fill-opacity', BASE_FILL_OPACITY);
-    setPatternVisible(true);
-    if (m.getLayer('zonas-vs-changed')) m.setLayoutProperty('zonas-vs-changed', 'visibility', 'visible'); // borde naranja del flip
+    m.setPaintProperty('zonas-fill', 'fill-opacity',
+      ['case', ['boolean', ['feature-state', 'vsChanged'], false], 0.92, 0.14]);
     return;
   }
   const sigla = cmpDeltaSigla.value;
@@ -2339,7 +2343,7 @@ onUnmounted(() => {
     <MapLegend
       v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema' || comparacionActiva"
       :entradas="legend" :sin-datos="sinDatos" :votos-sin-ubicacion="votosSinUbicacion" :zonas-sin-ubicacion="zonasSinUbicacion"
-      :comparacion-nota="comparacionActiva && cmpModo === 'ganador' ? 'Borde naranja: zonas donde cambió el partido ganador entre las dos elecciones.' : null" />
+      :comparacion-nota="comparacionActiva && cmpModo === 'ganador' ? 'Zonas a todo color: cambió el partido ganador entre las dos elecciones. Las atenuadas mantuvieron el mismo ganador.' : null" />
 
     <!-- Comparación entre elecciones (Fase 2): cómo ver el contraste. Va DEBAJO del mapa (junto a la
          leyenda) para no re-saturar arriba. 'Cambió ganador' = flip (borde naranja); 'Δ %' = magnitud

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -201,6 +201,9 @@ const gnivel = ref<Nivel>('lema');
 const nivelesDisponibles = ref<Nivel[]>(['lema']);
 /** Comparación entre elecciones activa (overlay ?vs= aplicado) → muestra leyenda + nota del borde naranja. */
 const comparacionActiva = ref(false);
+/** Comparación cargando (bajando la otra elección): atenuar TODAS las banderas para no mostrarlas a full
+ *  por ~1s antes de saber qué zonas cambiaron (evita el "flash" de la vista común al cargar). */
+const comparacionPendiente = ref(false);
 /** Sub-modo de comparación: 'ganador' (flip, borde naranja) | 'delta' (Δ% de un partido, escala divergente). */
 const cmpModo = ref<'ganador' | 'delta'>('ganador');
 /** Sigla del partido cuyo Δ% se colorea en modo delta. Default = ganador de la elección base. */
@@ -764,6 +767,7 @@ function drawFlagOverlay(m: MlMap): void {
 
     // Comparación modo "cambió ganador": atenuar las banderas de las zonas que NO cambiaron
     // → las que flipearon quedan a full y saltan. Mantiene TODAS las banderas visibles.
+    const dimAll = comparacionPendiente.value; // cargando comparación → atenuar TODAS
     const flipDim = comparacionActiva.value && cmpModo.value === 'ganador';
     // Pasada 1: flags recortados a cada polígono completo (un solo drawImage por barrio)
     for (const f of feats) {
@@ -772,7 +776,7 @@ function drawFlagOverlay(m: MlMap): void {
       const img = flagImgs[props.flagPattern as string];
       if (!img) continue;
       const fname = String(props.name ?? '');
-      const dimmed = flipDim && !m.getFeatureState({ source: 'zonas', id: fname })?.vsChanged;
+      const dimmed = dimAll || (flipDim && !m.getFeatureState({ source: 'zonas', id: fname })?.vsChanged);
       const bbox = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
       tracePath(f, bbox);
       if (!Number.isFinite(bbox.minX)) continue;
@@ -1535,6 +1539,15 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
   const fc = fcRef.value;
   if (!m || !fc || status.value !== 'listo') return;
   comparacionActiva.value = false; // se confirma al final si el overlay aplica
+  // Mientras baja la otra elección (~1s), atenuar TODAS las banderas (estado "cargando comparación")
+  // en vez de mostrarlas a full → sin flash. Solo en modo flip (en delta el render llega sólido).
+  if (cmpModo.value === 'ganador') {
+    comparacionPendiente.value = true;
+    setPatternVisible(true);
+    m.setPaintProperty('zonas-fill', 'fill-color', ['get', 'color']);
+    m.setPaintProperty('zonas-fill', 'fill-opacity', ['case', ['!=', ['get', 'flagPattern'], null], 0, 0.22]);
+    drawFlagOverlay(m);
+  }
   try {
     const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -1638,6 +1651,12 @@ async function applyComparisonOverlay(vs: string, baseEleccion: string, departam
     renderComparacionFill(); // aplica relleno según el sub-modo (ganador | delta)
   } catch {
     // Degradación silenciosa: si no hay datos de comparación, el mapa sigue normal.
+  } finally {
+    // Fin del estado "cargando": dejar de atenuar-todo. En éxito ya redibujó renderComparacionFill;
+    // en fallo, redibujar para restaurar las banderas a full (la comparación no se aplicó).
+    const pend = comparacionPendiente.value;
+    comparacionPendiente.value = false;
+    if (pend && !comparacionActiva.value) { setPatternVisible(true); m.setPaintProperty('zonas-fill', 'fill-opacity', BASE_FILL_OPACITY); drawFlagOverlay(m); }
   }
 }
 
@@ -1804,6 +1823,13 @@ async function reloadData(eleccion: string, departamento: string, nivel: string)
   // Resetear modo intensidad al cambiar de departamento (AC Story 2.3).
   intensidadActive = false;
   vistaMode.value = 'ganador';
+  // Si esta carga ya trae comparación (?vs=) en modo flip, entrar en "pendiente" ANTES del render
+  // base → el render base ya dibuja atenuado (0 frames a full). applyComparisonOverlay lo mantiene
+  // durante el fetch y su finally lo limpia.
+  {
+    const cmpPre = $comparison.get();
+    comparacionPendiente.value = !!(cmpPre.vs && cmpPre.vs !== eleccion && !(cmpPre.a && cmpPre.b)) && cmpModo.value === 'ganador';
+  }
   // Epic 10: resetear caches de hojas (el catálogo/shards son por elección×depto).
   catalogoOpcMeta = null;
   catalogoNodeLabel = new Map();
@@ -2282,6 +2308,11 @@ onMounted(async () => {
       m.on('mouseenter', 'zonas-circle', () => { m.getCanvas().style.cursor = 'pointer'; });
       m.on('mouseleave', 'zonas-circle', () => { m.getCanvas().style.cursor = ''; });
 
+      // Refresh con ?vs= en modo flip: entrar en "pendiente" ANTES del render base (0 frames a full).
+      {
+        const cmpPre = $comparison.get();
+        comparacionPendiente.value = !!(cmpPre.vs && cmpPre.vs !== props.eleccion && !(cmpPre.a && cmpPre.b)) && cmpModo.value === 'ganador';
+      }
       applySelection($selection.get().zona);
       applyOpcionFilter($selection.get().opcion);
       // Epic 10: si la URL ya traía ?sel=, colorear por la selección de hojas (Story 10.4).

--- a/src/components/map/CompareControls.vue
+++ b/src/components/map/CompareControls.vue
@@ -86,6 +86,7 @@ function exitCompare(): void { commit({ vs: null }); expanded.value = false; }
 .cmp {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 0.25rem 1rem;
   font-size: 0.75rem;

--- a/src/components/map/CompareControls.vue
+++ b/src/components/map/CompareControls.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 /**
- * Controles de comparación dual entre elecciones (Story 4.3).
+ * Controles de comparación entre elecciones (Story 4.3 · prototipo Fase 1).
  *
- * `client:idle`. Muestra botón entrar/salir del modo comparación.
- * Estado: $comparison.vs (URL ?vs=). Entrar → commit({ vs: otherEleccion }).
- * Solo renderiza el botón si el depto tiene ≥2 elecciones disponibles.
+ * `client:idle`. Permite elegir, de un dropdown, otra elección DEL MISMO TIPO contra la cual
+ * comparar (nacionales↔nacionales, internas↔internas, …). Entrar → commit({ vs }). Salir → commit({ vs: null }).
+ * El overlay (borde naranja en zonas donde cambió el partido ganador) lo aplica ChoroplethMap al ver `?vs=`.
+ *
+ * Solo elecciones del MISMO tipo son comparables: balotaje vs plebiscito tienen universos de opciones
+ * disjuntos → comparar ahí daría basura. El "tipo" se deriva quitando el año del id.
  */
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, computed } from 'vue';
 import { $comparison, commit } from '../../stores/map-state';
 
 const props = defineProps<{
@@ -31,39 +34,38 @@ const LABELS: Record<string, string> = {
 };
 function label(e: string): string { return LABELS[e] ?? e; }
 
-const comparisonVs = ref<string | null>(null);
+/** Tipo de elección = id sin el año (y lo que le siga). Solo se compara dentro del mismo tipo. */
+function tipoDe(e: string): string { return e.replace(/-?\d{4}.*$/, ''); }
 
+const comparisonVs = ref<string | null>(null);
 onMounted(() => {
-  $comparison.subscribe((cmp) => {
-    comparisonVs.value = cmp.vs;
-  });
+  $comparison.subscribe((cmp) => { comparisonVs.value = cmp.vs; });
 });
 
-function otherEleccion(): string | null {
-  return props.availableElecciones.find((e) => e !== props.eleccionActual) ?? null;
-}
+/** Elecciones comparables: mismo tipo, distinta del actual, ordenadas por año desc. */
+const comparables = computed<string[]>(() => {
+  const tipo = tipoDe(props.eleccionActual);
+  return props.availableElecciones
+    .filter((e) => e !== props.eleccionActual && tipoDe(e) === tipo)
+    .sort((a, b) => (b.match(/\d{4}/)?.[0] ?? '').localeCompare(a.match(/\d{4}/)?.[0] ?? ''));
+});
 
-function enterCompare(): void {
-  const other = otherEleccion();
-  if (other) commit({ vs: other });
+function onSelect(e: Event): void {
+  const val = (e.target as HTMLSelectElement).value;
+  commit({ vs: val || null });
 }
-
-function exitCompare(): void {
-  commit({ vs: null });
-}
+function exitCompare(): void { commit({ vs: null }); }
 </script>
 
 <template>
-  <div v-if="availableElecciones.length > 1" class="cmp">
-    <template v-if="comparisonVs">
-      <span class="cmp__text">Comparando con: <strong class="cmp__strong">{{ label(comparisonVs) }}</strong></span>
-      <button class="cmp__btn" type="button" @click="exitCompare">Salir</button>
-    </template>
-    <template v-else-if="otherEleccion()">
-      <button class="cmp__btn" type="button" @click="enterCompare">
-        Comparar con {{ label(otherEleccion()!) }}
-      </button>
-    </template>
+  <div v-if="comparables.length > 0" class="cmp">
+    <span class="cmp__lbl">Comparar con:</span>
+    <select class="cmp__sel" :value="comparisonVs ?? ''" @change="onSelect" aria-label="Elegí una elección para comparar">
+      <option value="">— elegí una elección —</option>
+      <option v-for="e in comparables" :key="e" :value="e">{{ label(e) }}</option>
+    </select>
+    <button v-if="comparisonVs" class="cmp__btn" type="button" @click="exitCompare">Salir</button>
+    <span v-if="comparisonVs" class="cmp__hint">Borde naranja = cambió el partido ganador</span>
   </div>
 </template>
 
@@ -71,14 +73,23 @@ function exitCompare(): void {
 .cmp {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0.375rem 1rem;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-surface-1);
   font-size: 0.75rem;
 }
-.cmp__text { color: var(--color-ink-soft); }
-.cmp__strong { color: var(--color-ink); font-weight: 600; }
+.cmp__lbl { color: var(--color-ink-soft); font-weight: 600; }
+.cmp__sel {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 0.25rem;
+  background: var(--color-paper);
+  color: var(--color-ink);
+  cursor: pointer;
+}
 .cmp__btn {
   background: none;
   border: none;
@@ -89,4 +100,5 @@ function exitCompare(): void {
   text-decoration: underline;
 }
 .cmp__btn:hover { color: var(--color-ink); }
+.cmp__hint { color: var(--color-ink-faint); font-size: 0.6875rem; }
 </style>

--- a/src/components/map/CompareControls.vue
+++ b/src/components/map/CompareControls.vue
@@ -2,12 +2,14 @@
 /**
  * Controles de comparación entre elecciones (Story 4.3 · prototipo Fase 1).
  *
- * `client:idle`. Permite elegir, de un dropdown, otra elección DEL MISMO TIPO contra la cual
- * comparar (nacionales↔nacionales, internas↔internas, …). Entrar → commit({ vs }). Salir → commit({ vs: null }).
- * El overlay (borde naranja en zonas donde cambió el partido ganador) lo aplica ChoroplethMap al ver `?vs=`.
+ * `client:idle`. UX de-saturada: cuando NO se está comparando, es solo un chip chico
+ * ("⇄ Comparar con otra elección") — sin banda permanente arriba del mapa. Al tocarlo se
+ * despliega un dropdown filtrado a elecciones del MISMO tipo (nacionales↔nacionales, …);
+ * al elegir una se entra en comparación (commit({ vs })). La explicación del borde naranja
+ * vive en la leyenda (debajo del mapa), no acá arriba.
  *
- * Solo elecciones del MISMO tipo son comparables: balotaje vs plebiscito tienen universos de opciones
- * disjuntos → comparar ahí daría basura. El "tipo" se deriva quitando el año del id.
+ * Solo elecciones del mismo tipo son comparables: balotaje vs plebiscito tienen universos de
+ * opciones disjuntos → comparar ahí daría basura. El "tipo" se deriva quitando el año del id.
  */
 import { onMounted, ref, computed } from 'vue';
 import { $comparison, commit } from '../../stores/map-state';
@@ -38,6 +40,7 @@ function label(e: string): string { return LABELS[e] ?? e; }
 function tipoDe(e: string): string { return e.replace(/-?\d{4}.*$/, ''); }
 
 const comparisonVs = ref<string | null>(null);
+const expanded = ref(false);
 onMounted(() => {
   $comparison.subscribe((cmp) => { comparisonVs.value = cmp.vs; });
 });
@@ -50,22 +53,32 @@ const comparables = computed<string[]>(() => {
     .sort((a, b) => (b.match(/\d{4}/)?.[0] ?? '').localeCompare(a.match(/\d{4}/)?.[0] ?? ''));
 });
 
+/** Mostrar el dropdown si ya estamos comparando o si el usuario tocó el chip. */
+const mostrarSelect = computed<boolean>(() => !!comparisonVs.value || expanded.value);
+
 function onSelect(e: Event): void {
   const val = (e.target as HTMLSelectElement).value;
   commit({ vs: val || null });
+  if (!val) expanded.value = false;
 }
-function exitCompare(): void { commit({ vs: null }); }
+function exitCompare(): void { commit({ vs: null }); expanded.value = false; }
 </script>
 
 <template>
   <div v-if="comparables.length > 0" class="cmp">
-    <span class="cmp__lbl">Comparar con:</span>
-    <select class="cmp__sel" :value="comparisonVs ?? ''" @change="onSelect" aria-label="Elegí una elección para comparar">
-      <option value="">— elegí una elección —</option>
-      <option v-for="e in comparables" :key="e" :value="e">{{ label(e) }}</option>
-    </select>
-    <button v-if="comparisonVs" class="cmp__btn" type="button" @click="exitCompare">Salir</button>
-    <span v-if="comparisonVs" class="cmp__hint">Borde naranja = cambió el partido ganador</span>
+    <!-- Inactivo: solo un chip chico (no banda permanente) -->
+    <button v-if="!mostrarSelect" class="cmp__chip" type="button" @click="expanded = true">
+      ⇄ Comparar con otra elección
+    </button>
+    <!-- Activo o desplegado: dropdown + salir -->
+    <template v-else>
+      <span class="cmp__lbl">Comparar con:</span>
+      <select class="cmp__sel" :value="comparisonVs ?? ''" @change="onSelect" aria-label="Elegí una elección para comparar">
+        <option value="">— elegí una elección —</option>
+        <option v-for="e in comparables" :key="e" :value="e">{{ label(e) }}</option>
+      </select>
+      <button class="cmp__btn" type="button" @click="exitCompare">{{ comparisonVs ? 'Salir' : 'Cancelar' }}</button>
+    </template>
   </div>
 </template>
 
@@ -73,13 +86,25 @@ function exitCompare(): void { commit({ vs: null }); }
 .cmp {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0.375rem 1rem;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-surface-1);
+  padding: 0.25rem 1rem;
   font-size: 0.75rem;
 }
+/* Chip compacto (estado inactivo): mínimo peso visual, no ocupa una banda completa. */
+.cmp__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 9999px;
+  background: var(--color-surface-1);
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  font-size: 0.7rem;
+}
+.cmp__chip:hover { color: var(--color-ink); border-color: var(--color-ink); }
+.cmp__chip:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
 .cmp__lbl { color: var(--color-ink-soft); font-weight: 600; }
 .cmp__sel {
   font-size: 0.75rem;
@@ -100,5 +125,4 @@ function exitCompare(): void { commit({ vs: null }); }
   text-decoration: underline;
 }
 .cmp__btn:hover { color: var(--color-ink); }
-.cmp__hint { color: var(--color-ink-faint); font-size: 0.6875rem; }
 </style>

--- a/src/components/map/MapLegend.vue
+++ b/src/components/map/MapLegend.vue
@@ -59,10 +59,8 @@ const fmt = (n: number): string => n.toLocaleString('es-UY');
       <span class="legend__nombre">{{ sinDatos }} zona(s) sin datos</span>
     </div>
   </div>
-  <!-- Comparación entre elecciones (prototipo): qué significa el borde naranja del mapa -->
-  <p v-if="props.comparacionNota" class="legend__nota legend__nota--cmp">
-    <span class="legend__cmp-swatch" aria-hidden="true"></span>{{ props.comparacionNota }}
-  </p>
+  <!-- Comparación entre elecciones: explica el realce-por-contraste del modo "cambió ganador" -->
+  <p v-if="props.comparacionNota" class="legend__nota legend__nota--cmp">{{ props.comparacionNota }}</p>
   <!-- Epic 16: limitación documentada — votos sin ubicación geográfica (series especiales/observados) -->
   <p v-if="(props.votosSinUbicacion ?? 0) > 0" class="legend__nota">
     ⚠ {{ fmt(props.votosSinUbicacion!) }} votos en {{ props.zonasSinUbicacion }} serie(s) sin ubicación geográfica

--- a/src/components/map/MapLegend.vue
+++ b/src/components/map/MapLegend.vue
@@ -20,6 +20,8 @@ const props = defineProps<{
   /** Epic 16: votos cuyo geoId no tiene polígono (series especiales/observados sin ubicación). */
   votosSinUbicacion?: number;
   zonasSinUbicacion?: number;
+  /** Comparación entre elecciones: explica qué significa el borde naranja (Story 4.3 · prototipo). */
+  comparacionNota?: string | null;
 }>();
 const fmt = (n: number): string => n.toLocaleString('es-UY');
 </script>
@@ -57,6 +59,10 @@ const fmt = (n: number): string => n.toLocaleString('es-UY');
       <span class="legend__nombre">{{ sinDatos }} zona(s) sin datos</span>
     </div>
   </div>
+  <!-- Comparación entre elecciones (prototipo): qué significa el borde naranja del mapa -->
+  <p v-if="props.comparacionNota" class="legend__nota legend__nota--cmp">
+    <span class="legend__cmp-swatch" aria-hidden="true"></span>{{ props.comparacionNota }}
+  </p>
   <!-- Epic 16: limitación documentada — votos sin ubicación geográfica (series especiales/observados) -->
   <p v-if="(props.votosSinUbicacion ?? 0) > 0" class="legend__nota">
     ⚠ {{ fmt(props.votosSinUbicacion!) }} votos en {{ props.zonasSinUbicacion }} serie(s) sin ubicación geográfica
@@ -120,5 +126,20 @@ const fmt = (n: number): string => n.toLocaleString('es-UY');
   font-size: 0.6875rem;
   line-height: 1.4;
   color: var(--color-ink-faint);
+}
+.legend__nota--cmp {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  color: var(--color-ink-muted);
+}
+.legend__cmp-swatch {
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 0.1875rem;
+  flex: none;
+  background: transparent;
+  box-shadow: inset 0 0 0 2px #f97316; /* mismo naranja del borde zonas-vs-changed */
 }
 </style>

--- a/src/components/map/MapLegend.vue
+++ b/src/components/map/MapLegend.vue
@@ -140,6 +140,6 @@ const fmt = (n: number): string => n.toLocaleString('es-UY');
   border-radius: 0.1875rem;
   flex: none;
   background: transparent;
-  box-shadow: inset 0 0 0 2px #f97316; /* mismo naranja del borde zonas-vs-changed */
+  border: 2px dashed #f97316; /* coincide con el borde punteado naranja de zonas-vs-changed */
 }
 </style>

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -7,6 +7,7 @@ import DataTable from '../../components/a11y/DataTable.astro';
 import OpcionAccordion from '../../components/selectors/OpcionAccordion.vue';
 import LevelSelector from '../../components/selectors/LevelSelector.vue';
 import EleccionSelector from '../../components/selectors/EleccionSelector.vue';
+import CompareControls from '../../components/map/CompareControls.vue';
 import Sello from '../../components/ui/Sello.astro';
 import ShareButton from '../../components/share/ShareButton.vue';
 import ExportButton from '../../components/share/ExportButton.vue';
@@ -132,6 +133,13 @@ const canonicalPath = `/${eleccion}/${departamento}`;
     />
     <!-- Toggle Zonas/Circuito (nivel geográfico) — control del mapa: va PEGADO arriba del mapa. -->
     <LevelSelector client:idle availableLevels={availableLevels} />
+    <!-- Comparación entre elecciones (prototipo Fase 1): dropdown de elecciones del mismo tipo;
+         marca con borde naranja las zonas donde cambió el partido ganador. -->
+    <CompareControls
+      client:idle
+      availableElecciones={availableElecciones}
+      eleccionActual={eleccion}
+    />
     <!-- Map-first: el mapa (héroe) va arriba de los selectores para quedar visible sin scrollear.
          transition:persist con nombre ESTABLE ("map") → el island MapLibre sobrevive la navegación
          entre departamentos aunque vaya antes en el DOM (NFR1). -->


### PR DESCRIPTION
## ⚠️ Rama de PREVIEW — no mergear a master

Prototipo para revisar la **UX de comparación entre elecciones** en remoto (no se puede ver localhost). Es un brainstorm en curso; el diseño/spec todavía no está cerrado.

## Qué hace (Fase 1 de la opción "Mapa de cambio")
Surface la comparación que **ya existía construida pero sin montar**: el overlay `?vs=` marca con **borde naranja** las zonas donde **cambió el partido ganador** entre dos elecciones.

- **CompareControls**: dropdown "Comparar con…" filtrado a elecciones del **mismo tipo** (nacionales↔nacionales, internas↔internas…). Balotaje vs plebiscito (universos disjuntos) no se ofrecen.
- Montado arriba del mapa en la vista por departamento.

## Cómo probarlo
Abrí una vista **por departamento** y elegí una elección en "Comparar con…". Demo con muchos cambios:
`…/nacionales-2024/rivera?vs=nacionales-2014` (21/36 series cambiaron).

## Qué NO incluye todavía
El **delta porcentual** (magnitud del cambio de un partido, escala divergente) = Fase 2 — requiere guardar la votación de la elección `vs` y reconciliar partidos entre elecciones. Se diseña después de tu feedback.

## Verificación
`astro check` 0 errores · `vitest` 55/55 · gates de datos OK · Playwright (Rivera) renderiza los bordes naranjas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)