### PR TITLE
fix(build): build completo en Vercel (OG + gates + tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "node scripts/generate-og.mjs && node scripts/generate-search-index.mjs && node scripts/gate-data.mjs && npx tsx scripts/gate-escaleras.ts && vitest run && astro build",
+    "vercel-build": "npm run build",
     "generate:og": "node scripts/generate-og.mjs",
     "generate:search": "node scripts/generate-search-index.mjs",
     "gate:data": "node scripts/gate-data.mjs",


### PR DESCRIPTION
## Qué arregla
- **Imágenes OG en 404 en producción.** Vercel corría `astro build` (preset Astro), no `npm run build`, así que `generate-og.mjs` nunca corría en deploy. Los PNGs (gitignored, artefactos de build) no llegaban a producción.
- **Gates y tests no corrían en deploy.** Mismo motivo: `gate-data`, `gate-escaleras` y `vitest` viven en el script `build`, que Vercel salteaba.

## Cómo
`"vercel-build": "npm run build"` — Vercel ejecuta el build completo. Solo código, sin `vercel.json` (que rompe el adapter @astrojs/vercel en `output: 'static'`).

## Cambio de comportamiento
Un gate o test que falle ahora pone el deploy **en rojo** (antes solo fallaba en GH Actions por cuota LFS). Es lo correcto: los gates deben bloquear el deploy.

## Verificación
- Preview verde = el build completo corre sin romperse.
- OG sobre producción tras merge: `curl -sI /og/internas-2024/montevideo.png` → 200.
- Si Vercel ignora `vercel-build` (OG sigue 404) → fallback a integración Astro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)