### PR TITLE
fix(og): generar OG en Vercel vía integración Astro

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import vercel from '@astrojs/vercel';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 import vercelCorsHeaders from './scripts/vercel-cors-headers.mjs';
+import buildAssetsOnVercel from './scripts/build-assets-on-vercel.mjs';
 
 // https://astro.build/config
 export default defineConfig({
@@ -22,7 +23,9 @@ export default defineConfig({
   // vercelCorsHeaders va DESPUÉS del adapter en el orden de hooks (el adapter se
   // antepone solo), así inyecta CORS/cache en config.json una vez que el adapter
   // ya lo escribió. Ver scripts/vercel-cors-headers.mjs.
-  integrations: [vue(), sitemap(), vercelCorsHeaders()],
+  // buildAssetsOnVercel genera OG + índice de búsqueda en build:start (solo en
+  // Vercel, que corre `astro build` y no `npm run build`). Ver el script.
+  integrations: [vue(), sitemap(), buildAssetsOnVercel(), vercelCorsHeaders()],
   vite: {
     plugins: [tailwindcss()],
     server: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "astro dev",
     "build": "node scripts/generate-og.mjs && node scripts/generate-search-index.mjs && node scripts/gate-data.mjs && npx tsx scripts/gate-escaleras.ts && vitest run && astro build",
-    "vercel-build": "npm run build",
     "generate:og": "node scripts/generate-og.mjs",
     "generate:search": "node scripts/generate-search-index.mjs",
     "gate:data": "node scripts/gate-data.mjs",

--- a/scripts/build-assets-on-vercel.mjs
+++ b/scripts/build-assets-on-vercel.mjs
@@ -1,0 +1,48 @@
+/**
+ * Integración Astro: genera en Vercel los artefactos de build que viven en
+ * `public/` y que el script `npm run build` produce ANTES de `astro build`.
+ *
+ * Por qué: Vercel corre `astro build` (build command del preset Astro), NO
+ * `npm run build` — confirmado porque `vercel-build: npm run build` fue ignorado
+ * (PR #27) y porque las OG (gitignored, generadas por `npm run build`) daban 404
+ * en producción. Al saltarse el script npm, nunca se generaban:
+ *   - imágenes OG (`public/og/{elec}/{depto}.png`) → 404 al compartir links.
+ *   - índice de búsqueda (`public/search-index.json`).
+ *
+ * Esta integración los genera en `astro:build:start` (antes de que Astro copie
+ * `public/` al output), pero SOLO en Vercel (`process.env.VERCEL`): en local
+ * `npm run build` ya los genera, y un `astro build` a secas no los necesita, así
+ * que no se duplica el trabajo.
+ *
+ * Nota: los gates (gate-data, gate-escaleras) y vitest del script `build`
+ * TAMPOCO corren en Vercel por el mismo motivo. Eso se deja como decisión aparte
+ * (correrlos en build:start los volvería bloqueantes del deploy — cambio de
+ * comportamiento). Ver memoria [[vercel-deploy-sin-vercel-json]].
+ */
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
+
+const STEPS = [
+  ['generate:og', 'node scripts/generate-og.mjs'],
+  ['generate:search', 'node scripts/generate-search-index.mjs'],
+];
+
+export default function buildAssetsOnVercel() {
+  return {
+    name: 'build-assets-on-vercel',
+    hooks: {
+      'astro:build:start': ({ logger }) => {
+        if (!process.env.VERCEL) {
+          logger?.info?.('[build-assets] fuera de Vercel — se omite (los genera `npm run build`).');
+          return;
+        }
+        for (const [label, cmd] of STEPS) {
+          logger?.info?.(`[build-assets] ${label}: ${cmd}`);
+          execSync(cmd, { cwd: ROOT, stdio: 'inherit' });
+        }
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Qué arregla
Las imágenes OG daban **404 en producción** al compartir links. Vercel corre `astro build` (no `npm run build`), así que `generate-og.mjs` nunca corría en deploy.

## Por qué no `vercel-build`
PR #27 probó `vercel-build: npm run build` y Vercel **lo ignoró** (OG siguió 404 en prod). Vercel usa el build command del preset Astro.

## Cómo
Integración Astro (`astro:build:start`) que genera OG + índice de búsqueda, **solo en Vercel** (`process.env.VERCEL`), antes de que Astro copie `public/` al output. En local `npm run build` ya los genera, así que el guard evita duplicar.

## Verificación
`curl -sI /og/internas-2024/montevideo.png` en producción tras merge → debe dar **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)