### PR TITLE
feat: Epic 21 — dimensión personas↔hoja (candidatos por credencial)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,13 @@ public/og/
 # la data procesada vive en public/data/. No bloquear el repo ni el build de Vercel con esto.
 data/raw/
 
+# Dimensión personas↔hoja (Epic 21): intermedios de build reproducibles desde CKAN
+# (scripts/build-personas-*.py). El person×hoja crudo pesa ~59 MB (duplicación de nóminas
+# de senadores × ~2800 hojas), fuera de escala para commitear/servir. El plan scopea el
+# servido/API (21.3) aparte; acá solo se construye y verifica standalone. Cuando exista 21.3,
+# el artefacto servido debe keyear persona→(elección, cargo, sublema/lema), NO person×hoja.
+public/data/personas/
+
 # Screenshots de verificación sueltos en la raíz (artefactos de debugging, no del producto).
 /*.png
 data/processed/geographic/_nacional/

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "etl:nacional": "npm run etl:nacional-geo && npm run etl:nacional-zona-geo && npm run etl:nacional-votes",
     "etl:annex": "python scripts/build-annex-series.py",
     "etl:totales-fetch": "python scripts/fetch-totales-ckan.py",
+    "etl:nominas-fetch": "python scripts/fetch-nominas-ckan.py",
     "etl:no-partidarios": "python scripts/build-no-partidarios.py",
     "gate:grises": "python scripts/gate-grises.py",
     "gate:no-partidarios": "python scripts/gate-no-partidarios.py",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "gate:api": "node scripts/gate-api-contract.mjs",
     "etl:api-index": "python scripts/build-api-index.py",
     "etl:api-dumps": "python scripts/build-api-dumps.py",
-    "etl:personas-hoja": "python scripts/build-personas-hoja.py"
+    "etl:personas-hoja": "python scripts/build-personas-hoja.py",
+    "etl:personas": "python scripts/build-personas-canonical.py"
   },
   "dependencies": {
     "@nanostores/vue": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "etl:no-partidarios": "python scripts/build-no-partidarios.py",
     "gate:grises": "python scripts/gate-grises.py",
     "gate:no-partidarios": "python scripts/gate-no-partidarios.py",
+    "gate:personas": "python scripts/gate-personas.py",
     "gate:api": "node scripts/gate-api-contract.mjs",
     "etl:api-index": "python scripts/build-api-index.py",
     "etl:api-dumps": "python scripts/build-api-dumps.py",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "gate:no-partidarios": "python scripts/gate-no-partidarios.py",
     "gate:api": "node scripts/gate-api-contract.mjs",
     "etl:api-index": "python scripts/build-api-index.py",
-    "etl:api-dumps": "python scripts/build-api-dumps.py"
+    "etl:api-dumps": "python scripts/build-api-dumps.py",
+    "etl:personas-hoja": "python scripts/build-personas-hoja.py"
   },
   "dependencies": {
     "@nanostores/vue": "^0.11.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,6 +59,46 @@ Corren en el build (`package.json → build`) y/o a demanda:
 > exacto a nivel país: ~2% nacionales, ~10% internas). Son dos productos oficiales distintos; no se fuerzan
 > a reconciliar. Spec: [`docs/superpowers/specs/2026-06-02-votos-no-partidarios-design.md`](../docs/superpowers/specs/2026-06-02-votos-no-partidarios-design.md).
 
+## Dimensión personas (candidatos × hoja × credencial)
+
+Construye una dimensión de personas indexada por credencial cívica, que une al mismo individuo a través de distintas elecciones. La métrica de cada persona es el **voto a su lista (hoja)**, no un voto personal — así funciona el voto legislativo en Uruguay.
+
+**Fuente:** recurso "Integración de hojas de votación" de la Corte Electoral, disponible en el [Catálogo de Datos Abiertos](https://catalogodatos.gub.uy/) por dataset de elección.
+
+**Cobertura por elección:**
+
+| Elección | Credencial disponible | Notas |
+|---|---|---|
+| `nacionales-2024` | Sí (`CredencialSerie` + `CredencialNumero`) | CSV utf-8 |
+| `departamentales-2025` | Sí | CSV utf-8; usar `integracion-de-hojas-full.csv` (19 deptos); el CSV truncado solo llega a Artigas |
+| `internas-2024` | Sí | XLSX; columna `TipoHoja` en lugar de `Candidatura` |
+| `nacionales-2019` | **No** | El recurso de integración existe pero no incluye la columna de credencial (esquema anterior a 2024) |
+| `nacionales-2014` | **No** | El dataset de nacionales-2014 no publica recurso de integración de hojas |
+
+Para agregar más elecciones (internas/departamentales pasadas): verificar que el recurso incluya `CredencialSerie`/`CredencialNumero`, agregar el slug y dataset-id a `TARGETS` en `fetch-nominas-ckan.py`. El cargo resultante será EDIL/INTENDENTE/ODN/ODD — **no SENADOR/REPRESENTANTE** — y el chequeo de cargos del gate aplica solo a slugs `nacionales-*`.
+
+**Scripts:**
+
+| Script | Comando | Función |
+|--------|---------|---------|
+| `fetch-nominas-ckan.py` | `npm run etl:nominas-fetch` | Baja el recurso "Integración de hojas" de CKAN para cada elección declarada en `TARGETS`. Idempotente. |
+| `build-personas-hoja.py` | `npm run etl:personas-hoja <eleccion>` | Parsea la integración → `personas-hoja.{eleccion}.json`: un registro por persona × hoja × cargo. `personaId = CredencialSerie-CredencialNumero` (estable entre elecciones). |
+| `build-personas-canonical.py` | `npm run etl:personas-canonical` | Consolida todos los shards → `personas.json`: una persona por credencial con sus apariciones cross-elección. Reporta M = personas en >1 elección (validación del join). |
+| `gate-personas.py` | `npm run gate:personas` | Valida: campos obligatorios presentes, cargos SENADOR/REPRESENTANTE en nacionales, tasa de hojas huérfanas <10%. |
+| `query-persona.py` | — | Verificación standalone: dado un nombre o credencial, imprime hojas, votos de cada lista y ranking departamental. Los votos se leen de **`hoja-local.json`** (no `votes.json`, que es solo a nivel lema/partido). |
+
+**Salidas:** `public/data/personas/personas-hoja.*.json` y `personas.json` (~160 MB total, 3 elecciones). Están **gitignoreadas** (intermedios de build pesado).
+
+**Flujo:**
+```bash
+npm run etl:nominas-fetch
+npm run etl:personas-hoja -- nacionales-2024
+npm run etl:personas-hoja -- internas-2024
+npm run etl:personas-hoja -- departamentales-2025
+npm run etl:personas
+npm run gate:personas
+```
+
 ## Utilidades y auditoría
 
 - `extract-vivir-sin-miedo.py` — extrae el Sí/No del plebiscito 2019 desde el PDF oficial, circuito por circuito.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,7 +70,7 @@ Construye una dimensión de personas indexada por credencial cívica, que une al
 | Elección | Credencial disponible | Notas |
 |---|---|---|
 | `nacionales-2024` | Sí (`CredencialSerie` + `CredencialNumero`) | CSV utf-8 |
-| `departamentales-2025` | Sí | CSV utf-8; usar `integracion-de-hojas-full.csv` (19 deptos); el CSV truncado solo llega a Artigas |
+| `departamentales-2025` | Sí | XLSX (19 deptos); el CSV de CKAN está truncado a Artigas — el fetch usa XLSX automáticamente (`PREFER_XLSX`) |
 | `internas-2024` | Sí | XLSX; columna `TipoHoja` en lugar de `Candidatura` |
 | `nacionales-2019` | **No** | El recurso de integración existe pero no incluye la columna de credencial (esquema anterior a 2024) |
 | `nacionales-2014` | **No** | El dataset de nacionales-2014 no publica recurso de integración de hojas |
@@ -87,7 +87,7 @@ Para agregar más elecciones (internas/departamentales pasadas): verificar que e
 | `gate-personas.py` | `npm run gate:personas` | Valida: campos obligatorios presentes, cargos SENADOR/REPRESENTANTE en nacionales, tasa de hojas huérfanas <10%. |
 | `query-persona.py` | — | Verificación standalone: dado un nombre o credencial, imprime hojas, votos de cada lista y ranking departamental. Los votos se leen de **`hoja-local.json`** (no `votes.json`, que es solo a nivel lema/partido). |
 
-**Salidas:** `public/data/personas/personas-hoja.*.json` y `personas.json` (~160 MB total, 3 elecciones). Están **gitignoreadas** (intermedios de build pesado).
+**Salidas:** `public/data/personas/personas-hoja.*.json` y `personas.json` (~340 MB total, 3 elecciones). Están **gitignoreadas** (intermedios de build pesado).
 
 **Flujo:**
 ```bash

--- a/scripts/build-personas-canonical.py
+++ b/scripts/build-personas-canonical.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Consolida public/data/personas/personas-hoja.*.json → public/data/personas/personas.json:
+una persona por credencial (personaId), con sus apariciones por elección. Uso:
+  python scripts/build-personas-canonical.py
+"""
+import json, os, glob
+from collections import defaultdict
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DIR = os.path.join(ROOT, 'public/data/personas')
+
+def main():
+    files = sorted(glob.glob(os.path.join(DIR, 'personas-hoja.*.json')))
+    if not files:
+        raise SystemExit("no hay personas-hoja.*.json (corré etl:personas-hoja)")
+    personas = {}
+    for path in files:
+        doc = json.load(open(path, encoding='utf-8'))
+        eleccion = doc["eleccion"]
+        for r in doc["registros"]:
+            pid = r["personaId"]
+            p = personas.setdefault(pid, {"personaId": pid, "nombres": [], "sexo": r.get("sexo"), "apariciones": []})
+            if r["nombre"] and r["nombre"] not in p["nombres"]:
+                p["nombres"].append(r["nombre"])
+            p["apariciones"].append({
+                "eleccion": eleccion, "departamento": r["departamento"], "hoja": r["hoja"],
+                "partido": r["partido"], "sublema": r.get("sublema"), "cargo": r["cargo"],
+                "ordinal": r.get("ordinal"), "titularSuplente": r.get("titularSuplente"),
+            })
+    out = sorted(personas.values(), key=lambda p: p["nombres"][0] if p["nombres"] else p["personaId"])
+    dest = os.path.join(DIR, 'personas.json')
+    with open(dest, 'w', encoding='utf-8') as f:
+        json.dump({"total": len(out), "personas": out}, f, ensure_ascii=False)
+    multi = sum(1 for p in out if len({a["eleccion"] for a in p["apariciones"]}) > 1)
+    print(f"{len(out)} personas consolidadas ({multi} en >1 elección) → {dest}")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build-personas-hoja.py
+++ b/scripts/build-personas-hoja.py
@@ -33,10 +33,11 @@ def persona_id(serie, numero):
 
 def read_rows(eleccion):
     base = os.path.join(ROOT, "data/raw/electoral", eleccion)
-    # Candidatos de nombres canónicos (preferidos) y alternativos ya en disco
+    # Candidatos de nombre para CSV: el full se prueba ANTES del canónico para evitar
+    # que un nominas-integracion.csv truncado (dep-2025: solo Artigas) tape al completo.
     csv_candidates = [
+        "integracion-de-hojas-full.csv",   # departamentales-2025 full (19 deptos) — prioritario
         "nominas-integracion.csv",
-        "integracion-de-hojas-full.csv",   # departamentales-2025 full (19 deptos)
         "integracion-de-hojas.csv",
     ]
     xlsx_candidates = [

--- a/scripts/build-personas-hoja.py
+++ b/scripts/build-personas-hoja.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Parsea la Integración de hojas de votación → public/data/personas/personas-hoja.{eleccion}.json:
+un registro por (persona × hoja × cargo). id de persona = credencial (estable cross-elección).
+Uso: python scripts/build-personas-hoja.py nacionales-2024
+"""
+import csv, json, os, sys, unicodedata
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CODE_DEPT = {"AR":"artigas","CA":"canelones","CL":"cerro_largo","CO":"colonia","DU":"durazno",
+    "FD":"florida","FS":"flores","LA":"lavalleja","MA":"maldonado","MO":"montevideo","PA":"paysandu",
+    "RN":"rio_negro","RO":"rocha","RV":"rivera","SA":"salto","SJ":"san_jose","SO":"soriano",
+    "TA":"tacuarembo","TT":"treinta_y_tres"}
+
+# Valores que indican "sin dato" — cubren: vacío, "NO APLICA" (con/sin punto),
+# "SIN SUBLEMA" y "SIN AGRUPACIÓN" / "SIN AGRUPACION" (con o sin tilde).
+VACIO = {"", "NO APLICA", "NO APLICA.", "N/A", "SIN SUBLEMA", "SIN AGRUPACION", "SIN AGRUPACIÓN"}
+
+
+def clean(s):
+    return (s or "").strip()
+
+
+def norm_upper(s):
+    """Normaliza a mayúsculas quitando tildes (para comparar contra VACIO)."""
+    s = unicodedata.normalize("NFD", s or "")
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    return s.upper().strip()
+
+
+def persona_id(serie, numero):
+    return f"{clean(serie).upper()}-{clean(numero)}"
+
+
+def read_rows(eleccion):
+    base = os.path.join(ROOT, "data/raw/electoral", eleccion)
+    csv_path = os.path.join(base, "nominas-integracion.csv")
+    if os.path.exists(csv_path) and os.path.getsize(csv_path) > 1024:
+        for enc in ("utf-8-sig", "utf-8", "latin-1"):
+            try:
+                with open(csv_path, encoding=enc) as f:
+                    return list(csv.DictReader(f))
+            except UnicodeDecodeError:
+                continue
+    xlsx = os.path.join(base, "nominas-integracion.xlsx")
+    if os.path.exists(xlsx):
+        from openpyxl import load_workbook
+        ws = load_workbook(xlsx, read_only=True).worksheets[0]
+        it = ws.iter_rows(values_only=True)
+        header = [str(c).strip() if c is not None else "" for c in next(it)]
+        return [dict(zip(header, [("" if v is None else str(v)) for v in row])) for row in it]
+    raise SystemExit(f"no hay integración para {eleccion} (corré etl:nominas-fetch)")
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise SystemExit("uso: build-personas-hoja.py <eleccion>")
+    eleccion = sys.argv[1]
+    rows = read_rows(eleccion)
+    out = []
+    for r in rows:
+        cod = clean(r.get("Departamento")).upper()
+        sub_raw = clean(r.get("Sublema"))
+        agr_raw = clean(r.get("Agrupacion"))
+        rec = {
+            "personaId": persona_id(r.get("CredencialSerie"), r.get("CredencialNumero")),
+            "nombre": clean(r.get("Nombre")),
+            "sexo": clean(r.get("Sexo")) or None,
+            "departamento": CODE_DEPT.get(cod, cod.lower()),
+            "hoja": clean(r.get("Numero")),
+            "partido": clean(r.get("PartidoPolitico")),
+            "agrupacion": agr_raw if norm_upper(agr_raw) not in VACIO else None,
+            "sublema": sub_raw if norm_upper(sub_raw) not in VACIO else None,
+            "cargo": clean(r.get("Candidatura")),
+            "ordinal": clean(r.get("Ordinal")) or None,
+            "titularSuplente": clean(r.get("TitularSuplente")) or None,
+        }
+        out.append(rec)
+    destdir = os.path.join(ROOT, "public/data/personas")
+    os.makedirs(destdir, exist_ok=True)
+    dest = os.path.join(destdir, f"personas-hoja.{eleccion}.json")
+    with open(dest, "w", encoding="utf-8") as f:
+        json.dump({"eleccion": eleccion, "registros": out}, f, ensure_ascii=False)
+    from collections import Counter
+    cargos = Counter(r["cargo"] for r in out)
+    print(f"{eleccion}: {len(out)} registros, {len({r['personaId'] for r in out})} personas únicas")
+    print(f"cargos: {dict(cargos.most_common())}")
+    size_mb = os.path.getsize(dest) / 1024 / 1024
+    print(f"tamaño: {size_mb:.2f} MB → {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build-personas-hoja.py
+++ b/scripts/build-personas-hoja.py
@@ -33,21 +33,42 @@ def persona_id(serie, numero):
 
 def read_rows(eleccion):
     base = os.path.join(ROOT, "data/raw/electoral", eleccion)
-    csv_path = os.path.join(base, "nominas-integracion.csv")
-    if os.path.exists(csv_path) and os.path.getsize(csv_path) > 1024:
-        for enc in ("utf-8-sig", "utf-8", "latin-1"):
-            try:
-                with open(csv_path, encoding=enc) as f:
-                    return list(csv.DictReader(f))
-            except UnicodeDecodeError:
-                continue
-    xlsx = os.path.join(base, "nominas-integracion.xlsx")
-    if os.path.exists(xlsx):
-        from openpyxl import load_workbook
-        ws = load_workbook(xlsx, read_only=True).worksheets[0]
-        it = ws.iter_rows(values_only=True)
-        header = [str(c).strip() if c is not None else "" for c in next(it)]
-        return [dict(zip(header, [("" if v is None else str(v)) for v in row])) for row in it]
+    # Candidatos de nombres canónicos (preferidos) y alternativos ya en disco
+    csv_candidates = [
+        "nominas-integracion.csv",
+        "integracion-de-hojas-full.csv",   # departamentales-2025 full (19 deptos)
+        "integracion-de-hojas.csv",
+    ]
+    xlsx_candidates = [
+        "nominas-integracion.xlsx",
+        "integracion-hojas-de-votacion.xlsx",  # internas-2024
+        "integracion-de-hojas.xlsx",
+    ]
+    for name in csv_candidates:
+        csv_path = os.path.join(base, name)
+        if os.path.exists(csv_path) and os.path.getsize(csv_path) > 1024:
+            for enc in ("utf-8-sig", "utf-8", "latin-1"):
+                try:
+                    with open(csv_path, encoding=enc) as f:
+                        rows = list(csv.DictReader(f))
+                    if rows:
+                        print(f"  leyendo {name} (enc={enc})")
+                        return rows
+                except UnicodeDecodeError:
+                    continue
+    from openpyxl import load_workbook
+    for name in xlsx_candidates:
+        xlsx = os.path.join(base, name)
+        if os.path.exists(xlsx):
+            print(f"  leyendo {name}")
+            ws = load_workbook(xlsx, read_only=True).worksheets[0]
+            it = ws.iter_rows(values_only=True)
+            header = [str(c).strip() if c is not None else "" for c in next(it)]
+            rows = [dict(zip(header, [("" if v is None else str(v)) for v in row])) for row in it]
+            # Descartar fila de encabezado repetida (internas-2024 tiene header en fila 2)
+            if rows and rows[0].get("Numero", "").lower() in ("numero", "número"):
+                rows = rows[1:]
+            return rows
     raise SystemExit(f"no hay integración para {eleccion} (corré etl:nominas-fetch)")
 
 
@@ -61,6 +82,8 @@ def main():
         cod = clean(r.get("Departamento")).upper()
         sub_raw = clean(r.get("Sublema"))
         agr_raw = clean(r.get("Agrupacion"))
+        # "Candidatura" en nacionales/departamentales; "TipoHoja" en internas
+        cargo_raw = clean(r.get("Candidatura") or r.get("TipoHoja") or "")
         rec = {
             "personaId": persona_id(r.get("CredencialSerie"), r.get("CredencialNumero")),
             "nombre": clean(r.get("Nombre")),
@@ -70,7 +93,7 @@ def main():
             "partido": clean(r.get("PartidoPolitico")),
             "agrupacion": agr_raw if norm_upper(agr_raw) not in VACIO else None,
             "sublema": sub_raw if norm_upper(sub_raw) not in VACIO else None,
-            "cargo": clean(r.get("Candidatura")),
+            "cargo": cargo_raw,
             "ordinal": clean(r.get("Ordinal")) or None,
             "titularSuplente": clean(r.get("TitularSuplente")) or None,
         }

--- a/scripts/build-personas-hoja.py
+++ b/scripts/build-personas-hoja.py
@@ -99,6 +99,23 @@ def main():
             "titularSuplente": clean(r.get("TitularSuplente")) or None,
         }
         out.append(rec)
+
+    # Guard FIX 3: abortar si la elección no tiene credenciales válidas.
+    # nacionales-2019 y nacionales-2014 NO tienen CredencialSerie/CredencialNumero,
+    # lo que produce masivamente personaId="-" → shard inútil.
+    if out:
+        sin_cred = sum(
+            1 for rec in out
+            if not rec["personaId"] or rec["personaId"] == "-"
+        )
+        tasa = sin_cred / len(out)
+        if tasa > 0.5:
+            raise SystemExit(
+                f"ABORTANDO: la elección '{eleccion}' no tiene credencial en la integración "
+                f"({sin_cred:,}/{len(out):,} registros = {tasa:.0%} sin personaId) "
+                f"— no apta para la dimensión por credencial."
+            )
+
     destdir = os.path.join(ROOT, "public/data/personas")
     os.makedirs(destdir, exist_ok=True)
     dest = os.path.join(destdir, f"personas-hoja.{eleccion}.json")

--- a/scripts/fetch-nominas-ckan.py
+++ b/scripts/fetch-nominas-ckan.py
@@ -17,6 +17,8 @@ TARGETS = {
     'internas-2024':         'corte-electoral-elecciones-internas-de-los-partidos-politicos-2024',
     'departamentales-2025':  'corte-electoral-elecciones_departamentales_y_municipales_2025',
 }
+# Elecciones cuyo CSV de CKAN está truncado; se prefiere el XLSX (completo).
+PREFER_XLSX = {'departamentales-2025'}
 RES_SUB = 'integraci'  # matchea "Integración de hojas de votación"
 
 def ckan(action, **params):
@@ -33,7 +35,9 @@ def resolve(dataset, fmt):
 def fetch_one(eleccion, dataset):
     destdir = os.path.join(ROOT, 'data/raw/electoral', eleccion)
     os.makedirs(destdir, exist_ok=True)
-    for fmt, ext in (('CSV', 'csv'), ('XLSX', 'xlsx')):
+    # Orden CSV→XLSX por defecto; PREFER_XLSX invierte: XLSX→CSV para datasets con CSV truncado.
+    fmts = (('XLSX', 'xlsx'), ('CSV', 'csv')) if eleccion in PREFER_XLSX else (('CSV', 'csv'), ('XLSX', 'xlsx'))
+    for fmt, ext in fmts:
         url = resolve(dataset, fmt)
         if not url:
             continue
@@ -46,7 +50,7 @@ def fetch_one(eleccion, dataset):
         with open(dest, 'wb') as f:
             f.write(data)
         print(f"  {eleccion}: bajado {len(data)//1024} KB → {dest}"); return
-    raise SystemExit(f"no encontré recurso de integración para {eleccion}")
+    print(f"  AVISO: no encontré recurso de integración para {eleccion} (elección sin nóminas, skip)")
 
 def main():
     sel = sys.argv[1:] or list(TARGETS)

--- a/scripts/fetch-nominas-ckan.py
+++ b/scripts/fetch-nominas-ckan.py
@@ -11,9 +11,11 @@ UA = {'User-Agent': 'uruguay-electoral-map/1.0 (nominas fetch)'}
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 TARGETS = {
-    'nacionales-2024': 'corte-electoral-elecciones-nacionales-2024',
-    'nacionales-2019': 'corte-electoral-elecciones-nacionales-2019',
-    'nacionales-2014': 'corte-electoral-elecciones_nacionales_2014',
+    'nacionales-2024':       'corte-electoral-elecciones-nacionales-2024',
+    'nacionales-2019':       'corte-electoral-elecciones-nacionales-2019',
+    'nacionales-2014':       'corte-electoral-elecciones_nacionales_2014',
+    'internas-2024':         'corte-electoral-elecciones-internas-de-los-partidos-politicos-2024',
+    'departamentales-2025':  'corte-electoral-elecciones_departamentales_y_municipales_2025',
 }
 RES_SUB = 'integraci'  # matchea "Integración de hojas de votación"
 

--- a/scripts/fetch-nominas-ckan.py
+++ b/scripts/fetch-nominas-ckan.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Baja de CKAN (Corte Electoral) el recurso 'Integración de hojas de votación' por elección — la
+fuente del mapeo persona↔hoja (nombre, cargo, hoja, credencial). Idempotente. Uso:
+  python scripts/fetch-nominas-ckan.py            # todas las TARGETS
+  python scripts/fetch-nominas-ckan.py nacionales-2024
+"""
+import urllib.request, urllib.parse, json, os, sys
+
+API = 'https://catalogodatos.gub.uy/api/3/action/'
+UA = {'User-Agent': 'uruguay-electoral-map/1.0 (nominas fetch)'}
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+TARGETS = {
+    'nacionales-2024': 'corte-electoral-elecciones-nacionales-2024',
+    'nacionales-2019': 'corte-electoral-elecciones-nacionales-2019',
+    'nacionales-2014': 'corte-electoral-elecciones_nacionales_2014',
+}
+RES_SUB = 'integraci'  # matchea "Integración de hojas de votación"
+
+def ckan(action, **params):
+    url = API + action + '?' + urllib.parse.urlencode(params)
+    return json.load(urllib.request.urlopen(urllib.request.Request(url, headers=UA), timeout=60))
+
+def resolve(dataset, fmt):
+    pkg = ckan('package_show', id=dataset)['result']
+    for r in pkg['resources']:
+        if r.get('format', '').upper() == fmt and RES_SUB in r.get('name', '').lower():
+            return r['url']
+    return None
+
+def fetch_one(eleccion, dataset):
+    destdir = os.path.join(ROOT, 'data/raw/electoral', eleccion)
+    os.makedirs(destdir, exist_ok=True)
+    for fmt, ext in (('CSV', 'csv'), ('XLSX', 'xlsx')):
+        url = resolve(dataset, fmt)
+        if not url:
+            continue
+        dest = os.path.join(destdir, f'nominas-integracion.{ext}')
+        if os.path.exists(dest) and os.path.getsize(dest) > 1024:
+            print(f"  {eleccion}: ya existe {dest} (skip)"); return
+        data = urllib.request.urlopen(urllib.request.Request(url, headers=UA), timeout=300).read()
+        if len(data) < 1024 and fmt == 'CSV':
+            print(f"  {eleccion}: CSV vacío ({len(data)}B), pruebo XLSX"); continue
+        with open(dest, 'wb') as f:
+            f.write(data)
+        print(f"  {eleccion}: bajado {len(data)//1024} KB → {dest}"); return
+    raise SystemExit(f"no encontré recurso de integración para {eleccion}")
+
+def main():
+    sel = sys.argv[1:] or list(TARGETS)
+    for e in sel:
+        if e not in TARGETS:
+            raise SystemExit(f"elección desconocida: {e} (válidas: {list(TARGETS)})")
+        fetch_one(e, TARGETS[e])
+
+if __name__ == '__main__':
+    print('=== Fetch nóminas-integración (CKAN Corte Electoral) ===')
+    main()
+    print('Listo.')

--- a/scripts/gate-personas.py
+++ b/scripts/gate-personas.py
@@ -3,7 +3,9 @@
   - algún registro no tiene personaId (credencial) o hoja;
   - faltan cargos legislativos esperados (SENADOR / REPRESENTANTE) en nacionales;
   - la tasa de hojas huérfanas absolutas supera el umbral HUERFANAS_HARD_PCT
-    (indicaría un bug de formato/join sistémico, no candidaturas sin votos).
+    (indicaría un bug de formato/join sistémico, no candidaturas sin votos);
+  - la sonda de conteo no-cero falla: resuelve una persona legislativa real → 0 votos
+    (indicaría que el join hoja→opcionId→hoja-local está roto sin que nada lo detecte).
 
 DISEÑO DEL CHEQUEO DE FANTASMAS:
   En elecciones nacionales, una hoja puede presentarse en los 19 departamentos pero
@@ -28,12 +30,22 @@ DISEÑO DEL CHEQUEO DE FANTASMAS:
   OK del gate significa: "todas las hojas con ≥1 voto en algún depto están
   correctamente representadas en la nómina". No certifica hojas con cero votos totales.
 
+DISEÑO DE LA SONDA DE CONTEO NO-CERO:
+  Por cada shard, toma la persona con más apariciones entre los cargos legislativos
+  (SENADOR/REPRESENTANTE en nacionales, ODN/ODD en internas, JUNTA DEPARTAMENTAL en
+  departamentales). Resuelve su hoja → opcionId via catalogo.json y suma votos desde
+  hoja-local.json (misma lógica que query-persona.py). Si el total da 0, el gate falla:
+  ese resultado implica que el join produce votos, no solo que la hoja existe.
+  Si no hay hoja-local.json para la elección se omite la sonda (advertencia).
+
 Uso: python scripts/gate-personas.py
 """
 import json
 import os
 import glob
 import sys
+import unicodedata
+from collections import Counter, defaultdict
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DIR = os.path.join(ROOT, "public", "data", "personas")
@@ -43,6 +55,8 @@ DIR = os.path.join(ROOT, "public", "data", "personas")
 # ---------------------------------------------------------------------------
 
 _union_cache: dict[str, set[str]] = {}
+_cat_cache: dict[str, dict] = {}
+_hl_cache: dict[str, dict[str, int]] = {}
 
 
 def hojas_union_catalogo(eleccion: str) -> set[str]:
@@ -60,6 +74,123 @@ def hojas_union_catalogo(eleccion: str) -> set[str]:
                     union.add(str(o["hoja"]))
     _union_cache[eleccion] = union
     return union
+
+
+def _get_cat(eleccion: str, depto: str) -> dict:
+    """Carga y cachea catalogo.json de una combinación eleccion+depto."""
+    key = f"{eleccion}/{depto}"
+    if key not in _cat_cache:
+        path = os.path.join(ROOT, "public", "data", eleccion, depto, "catalogo.json")
+        _cat_cache[key] = json.load(open(path, encoding="utf-8")) if os.path.exists(path) else {}
+    return _cat_cache[key]
+
+
+def _hoja_opcion(cat_doc: dict, hoja: str, partido: str | None = None) -> str | None:
+    """Resuelve hoja → opcionId. Si hay ambigüedad, desambigua por partido.
+
+    Prueba el slug completo ("partido-nacional") Y sin el prefijo "partido-"
+    ("nacional") para cubrir opcionIds que omiten dicho prefijo.
+    """
+    hoja_str = str(hoja)
+    candidates = [
+        o["id"]
+        for c in cat_doc.get("contiendas", [])
+        for o in c.get("opciones", [])
+        if str(o.get("hoja")) == hoja_str
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    if partido:
+        slug = unicodedata.normalize("NFD", partido)
+        slug = "".join(ch for ch in slug if unicodedata.category(ch) != "Mn")
+        slug = slug.lower().replace(" ", "-")
+        slug_no_prefix = slug[len("partido-"):] if slug.startswith("partido-") else slug
+        for oid in candidates:
+            oid_l = oid.lower()
+            if slug in oid_l or slug_no_prefix in oid_l:
+                return oid
+    return candidates[0]
+
+
+def _oid_totals(eleccion: str, depto: str) -> dict[str, int]:
+    """Carga hoja-local.json y suma votos por opcionId (total depto). Cacheado."""
+    key = f"{eleccion}/{depto}"
+    if key not in _hl_cache:
+        hl_path = os.path.join(ROOT, "public", "data", eleccion, depto, "hoja-local.json")
+        if not os.path.exists(hl_path):
+            _hl_cache[key] = {}
+        else:
+            doc = json.load(open(hl_path, encoding="utf-8"))
+            totals: dict[str, int] = defaultdict(int)
+            for z in doc.get("zonas", []):
+                for o in z.get("porOpcion", []):
+                    totals[o["opcionId"]] += o.get("votos", 0)
+            _hl_cache[key] = dict(totals)
+    return _hl_cache[key]
+
+
+# Cargos legislativos por tipo de elección (para la sonda de conteo)
+CARGOS_SONDA: dict[str, set[str]] = {
+    "nacionales": {"SENADOR", "REPRESENTANTE"},
+    "internas": {"ODN", "ODD"},
+    "departamentales": {"JUNTA DEPARTAMENTAL"},
+}
+
+
+def sonda_conteo(eleccion: str, regs: list[dict]) -> tuple[bool, str]:
+    """Sonda: toma la persona con más apariciones en cargos legislativos y verifica
+    que su join hoja→opcionId→hoja-local produce >0 votos en al menos un depto.
+
+    Retorna (ok: bool, mensaje: str).
+    """
+    # Determinar tipo de elección para elegir cargos
+    tipo = next((t for t in CARGOS_SONDA if eleccion.startswith(t)), None)
+    if tipo is None:
+        return True, f"  sonda: elección '{eleccion}' sin cargos sonda definidos — omitida"
+
+    target_cargos = CARGOS_SONDA[tipo]
+    leg = [r for r in regs if r.get("cargo", "").upper() in target_cargos]
+    if not leg:
+        return True, f"  sonda: no hay registros con cargos {target_cargos} en {eleccion} — omitida"
+
+    # Persona con más apariciones entre los legislativos
+    cnt = Counter(r["personaId"] for r in leg)
+    probe_id, _ = cnt.most_common(1)[0]
+    probe_recs = [r for r in leg if r["personaId"] == probe_id]
+    nombre = probe_recs[0]["nombre"]
+    hoja = probe_recs[0]["hoja"]
+
+    # Deduplicar por depto para no sumar el mismo depto dos veces (persona con
+    # múltiples cargos en el mismo departamento).
+    deptos_vistos: set[str] = set()
+    total_votos = 0
+    for r in probe_recs:
+        depto = r["departamento"]
+        if depto in deptos_vistos:
+            continue
+        deptos_vistos.add(depto)
+        partido = r.get("partido", "")
+        cat_doc = _get_cat(eleccion, depto)
+        if not cat_doc:
+            continue
+        oid = _hoja_opcion(cat_doc, hoja, partido)
+        if not oid:
+            continue
+        totals = _oid_totals(eleccion, depto)
+        total_votos += totals.get(oid, 0)
+
+    msg_probe = (
+        f"  sonda [{eleccion}]: {probe_id} ({nombre}), hoja {hoja}, "
+        f"{len(deptos_vistos)} depto(s) → {total_votos:,} votos"
+    )
+    if total_votos == 0:
+        return False, (
+            f"join roto: persona {probe_id} ({nombre}) hoja {hoja} "
+            f"resolvió 0 votos en {eleccion} — verificá catalogo.json y hoja-local.json"
+        )
+    return True, msg_probe
 
 
 # ---------------------------------------------------------------------------
@@ -80,10 +211,9 @@ HUERFANAS_HARD_PCT = 10.0
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    from collections import defaultdict
-
     errs: list[str] = []
     infos: list[str] = []
+    probe_msgs: list[str] = []
 
     shards = sorted(glob.glob(os.path.join(DIR, "personas-hoja.*.json")))
     if not shards:
@@ -149,7 +279,17 @@ def main() -> None:
                 # Tasa baja → candidaturas reales sin votos (verificado en fuente) → info
                 infos.append(msg)
 
+        # 4. Sonda de conteo no-cero: verifica que el join hoja→opcionId→hoja-local
+        #    produzca votos reales para una persona legislativa conocida del shard.
+        sonda_ok, sonda_msg = sonda_conteo(eleccion, regs)
+        probe_msgs.append(sonda_msg)
+        if not sonda_ok:
+            errs.append(sonda_msg)
+
     print(f"[gate:personas] {len(shards)} shard(s), {total_regs_global:,} registros")
+    print("  sondas de conteo no-cero:")
+    for pm in probe_msgs:
+        print(pm)
     if infos:
         print(f"  · {len(infos)} aviso(s) de hojas sin votos (tasa <{HUERFANAS_HARD_PCT:.0f}%, esperado):")
         for i in infos:
@@ -163,7 +303,8 @@ def main() -> None:
 
     print(
         "[gate:personas] OK — campos completos, cargos legislativos presentes, "
-        f"tasa de hojas huérfanas dentro del umbral (<{HUERFANAS_HARD_PCT:.0f}%)."
+        f"tasa de hojas huérfanas dentro del umbral (<{HUERFANAS_HARD_PCT:.0f}%), "
+        "sonda de votos > 0."
     )
 
 

--- a/scripts/gate-personas.py
+++ b/scripts/gate-personas.py
@@ -2,8 +2,8 @@
 """Gate de integridad de la dimensión personas↔hoja. Falla (exit 1) si:
   - algún registro no tiene personaId (credencial) o hoja;
   - faltan cargos legislativos esperados (SENADOR / REPRESENTANTE) en nacionales;
-  - una hoja de la nómina no existe en NINGÚN catálogo de ningún depto de la elección
-    (hoja fantasma absoluta = 0 votos en todo el país).
+  - la tasa de hojas huérfanas absolutas supera el umbral HUERFANAS_HARD_PCT
+    (indicaría un bug de formato/join sistémico, no candidaturas sin votos).
 
 DISEÑO DEL CHEQUEO DE FANTASMAS:
   En elecciones nacionales, una hoja puede presentarse en los 19 departamentos pero
@@ -13,17 +13,20 @@ DISEÑO DEL CHEQUEO DE FANTASMAS:
     · Si la hoja existe en al menos un depto → la candidatura fue real y obtuvo votos en
       algún lugar. Que tenga 0 votos en un depto concreto es comportamiento esperado.
     · Si la hoja no existe en NINGÚN catálogo → la candidatura se presentó pero no
-      obtuvo ningún voto en todo el país (12 hojas en nacionales-2024, 1.23% de
-      registros). Se reporta como advertencia y cuenta como falla del gate.
+      obtuvo ningún voto en todo el país. Verificado contra desglose-de-votos.csv: las 12
+      hojas huérfanas de nacionales-2024 (PN fracciones + 1 CA) constan en la nómina
+      oficial pero suman 0 votos en la fuente cruda. Es comportamiento legítimo.
 
   NO se usa un chequeo per-depto estricto porque generaría ~5.893 falsos positivos (2.7%)
   en nacionales-2024, todos correspondientes a presentaciones locales con cero votos
   locales pero votos reales en otros deptos — el join NO está roto en esos casos.
 
-  OK del gate significa: "todas las hojas que recibieron votos en algún depto están
-  correctamente representadas en la nómina". No certifica que hojas con cero votos
-  totales sean candidaturas canceladas — eso requiere cruzar con registros de habilitación
-  de la Corte Electoral.
+  UMBRAL DE ALARMA: si más del 10% de las hojas distintas en la nómina son huérfanas
+  (nunca en ningún catálogo), es señal de un bug sistémico (ej. cero a la izquierda,
+  mismatch str/int). Ese caso → exit 1. Con <10% se reporta como info "·" y exit 0.
+
+  OK del gate significa: "todas las hojas con ≥1 voto en algún depto están
+  correctamente representadas en la nómina". No certifica hojas con cero votos totales.
 
 Uso: python scripts/gate-personas.py
 """
@@ -31,39 +34,15 @@ import json
 import os
 import glob
 import sys
-from functools import lru_cache
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DIR = os.path.join(ROOT, "public", "data", "personas")
 
 # ---------------------------------------------------------------------------
-# Helpers con caché (evita recargar catálogos 217 k veces)
+# Helpers con caché (evita recargar catálogos por cada shard)
 # ---------------------------------------------------------------------------
 
-_cat_cache: dict[str, set[str]] = {}
 _union_cache: dict[str, set[str]] = {}
-
-
-def hojas_catalogo(eleccion: str, depto: str) -> set[str] | None:
-    """Retorna el set de hojas del catálogo de un depto/elección (cacheado).
-    Retorna None si el catálogo no existe.
-    """
-    key = (eleccion, depto)
-    if key in _cat_cache:
-        return _cat_cache[key]
-    cat_path = os.path.join(ROOT, "public", "data", eleccion, depto, "catalogo.json")
-    if not os.path.exists(cat_path):
-        _cat_cache[key] = None
-        return None
-    with open(cat_path, encoding="utf-8") as f:
-        doc = json.load(f)
-    hojas: set[str] = set()
-    for c in doc.get("contiendas", []):
-        for o in c.get("opciones", []):
-            if o.get("hoja"):
-                hojas.add(str(o["hoja"]))
-    _cat_cache[key] = hojas
-    return hojas
 
 
 def hojas_union_catalogo(eleccion: str) -> set[str]:
@@ -87,18 +66,13 @@ def hojas_union_catalogo(eleccion: str) -> set[str]:
 # Validaciones por cargo
 # ---------------------------------------------------------------------------
 
-# Cargos cuya hoja es de alcance NACIONAL (misma papeleta en todos los deptos).
-# El catálogo per-depto los incluye solo cuando recibieron votos en ese depto, por lo
-# que un chequeo per-depto generaría falsos positivos masivos. Se validan contra la
-# unión de catálogos (que sí los cubre donde obtuvieron votos).
-CARGOS_NACIONALES = {"PRESIDENCIAL", "VICEPRESIDENCIAL", "SENADOR"}
-
-# Cargos por circunscripción departamental. Se validan primero per-depto; si tampoco
-# están en la unión se clasifican como huérfanos absolutos.
-CARGOS_POR_DEPTO = {"REPRESENTANTE", "JUNTA ELECTORAL"}
-
 # Cargos legislativos mínimos esperados en una elección de tipo "nacionales"
 CARGOS_LEGISLATIVOS_NACIONALES = {"SENADOR", "REPRESENTANTE"}
+
+# Umbral duro: si el porcentaje de hojas distintas huérfanas supera este valor
+# se asume un bug sistémico de join/formato y el gate falla con exit 1.
+# En nacionales-2024 la tasa real es 12/338 = 3.6% → bien por debajo del 10%.
+HUERFANAS_HARD_PCT = 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -106,12 +80,17 @@ CARGOS_LEGISLATIVOS_NACIONALES = {"SENADOR", "REPRESENTANTE"}
 # ---------------------------------------------------------------------------
 
 def main() -> None:
+    from collections import defaultdict
+
     errs: list[str] = []
+    infos: list[str] = []
 
     shards = sorted(glob.glob(os.path.join(DIR, "personas-hoja.*.json")))
     if not shards:
         print(f"[gate:personas] No se encontraron shards en {DIR}")
         sys.exit(1)
+
+    total_regs_global = 0
 
     for path in shards:
         with open(path, encoding="utf-8") as f:
@@ -119,6 +98,7 @@ def main() -> None:
 
         eleccion: str = doc["eleccion"]
         regs: list[dict] = doc["registros"]
+        total_regs_global += len(regs)
 
         # 1. Campos obligatorios
         sin_cred = [r for r in regs if not r.get("personaId") or str(r["personaId"]).startswith("-")]
@@ -138,49 +118,52 @@ def main() -> None:
                     f"{sorted(faltantes)} (cargos presentes: {sorted(cargos_presentes)})"
                 )
 
-        # 3. Hojas fantasma (solo registros que tienen hoja)
-        # Precargamos la unión una sola vez por elección
+        # 3. Hojas huérfanas absolutas (hoja en nómina pero 0 votos en cualquier depto)
+        # Se usa la UNIÓN de todos los catálogos de la elección, no el catálogo per-depto,
+        # para evitar falsos positivos por hojas nacionales con votos solo en algunos deptos.
         union = hojas_union_catalogo(eleccion)
+        all_nomina_hojas = {str(r["hoja"]) for r in regs if r.get("hoja")}
 
-        # Huérfanos absolutos: hoja que no existe en NINGÚN catálogo de la elección
-        # (candidatura que obtuvo 0 votos en todo el país)
-        huerfanos_hojas: set[str] = set()
-        for r in regs:
-            h = r.get("hoja")
-            if h and str(h) not in union:
-                huerfanos_hojas.add(str(h))
+        huerfanas = all_nomina_hojas - union
+        tasa_pct = 100.0 * len(huerfanas) / len(all_nomina_hojas) if all_nomina_hojas else 0.0
 
-        if huerfanos_hojas:
-            n_regs = sum(1 for r in regs if r.get("hoja") and str(r["hoja"]) in huerfanos_hojas)
-            # Detalle por partido para diagnóstico
-            from collections import defaultdict
+        if huerfanas:
+            n_regs = sum(1 for r in regs if r.get("hoja") and str(r["hoja"]) in huerfanas)
             partido_count: dict[str, int] = defaultdict(int)
             for r in regs:
-                if r.get("hoja") and str(r["hoja"]) in huerfanos_hojas:
+                if r.get("hoja") and str(r["hoja"]) in huerfanas:
                     partido_count[r.get("partido", "?")] += 1
             partido_str = ", ".join(
                 f"{p}:{c}" for p, c in sorted(partido_count.items(), key=lambda x: -x[1])
             )
-            errs.append(
-                f"{eleccion}: {len(huerfanos_hojas)} hojas que no recibieron votos en "
-                f"ningún depto → {n_regs} registros huérfanos ({partido_str}). "
-                f"Hojas: {sorted(huerfanos_hojas)}"
+            msg = (
+                f"{eleccion}: {len(huerfanas)} hojas ({tasa_pct:.1f}%) sin votos en ningún "
+                f"depto → {n_regs} registros ({100.0*n_regs/len(regs):.2f}% del shard). "
+                f"Candidaturas presentadas con 0 votos totales ({partido_str}). "
+                f"Hojas: {sorted(huerfanas)}"
             )
+            if tasa_pct >= HUERFANAS_HARD_PCT:
+                # Tasa alta → probable bug sistémico de join/formato → falla dura
+                errs.append(msg)
+            else:
+                # Tasa baja → candidaturas reales sin votos (verificado en fuente) → info
+                infos.append(msg)
+
+    print(f"[gate:personas] {len(shards)} shard(s), {total_regs_global:,} registros")
+    if infos:
+        print(f"  · {len(infos)} aviso(s) de hojas sin votos (tasa <{HUERFANAS_HARD_PCT:.0f}%, esperado):")
+        for i in infos:
+            print("    -", i)
 
     if errs:
         print("[gate:personas] FALLÓ:")
         for e in errs:
-            print("  -", e)
+            print("  ✗", e)
         sys.exit(1)
 
-    total_regs = sum(
-        len(json.load(open(p, encoding="utf-8"))["registros"])
-        for p in shards
-    )
     print(
-        f"[gate:personas] OK — {len(shards)} shard(s), {total_regs:,} registros, "
-        "sin fantasmas absolutos (hojas con 0 votos en algún depto son presentaciones "
-        "locales sin votos, comportamiento esperado en nacionales)."
+        "[gate:personas] OK — campos completos, cargos legislativos presentes, "
+        f"tasa de hojas huérfanas dentro del umbral (<{HUERFANAS_HARD_PCT:.0f}%)."
     )
 
 

--- a/scripts/gate-personas.py
+++ b/scripts/gate-personas.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Gate de integridad de la dimensión personas↔hoja. Falla (exit 1) si:
+  - algún registro no tiene personaId (credencial) o hoja;
+  - faltan cargos legislativos esperados (SENADOR / REPRESENTANTE) en nacionales;
+  - una hoja de la nómina no existe en NINGÚN catálogo de ningún depto de la elección
+    (hoja fantasma absoluta = 0 votos en todo el país).
+
+DISEÑO DEL CHEQUEO DE FANTASMAS:
+  En elecciones nacionales, una hoja puede presentarse en los 19 departamentos pero
+  obtener votos solo en algunos. El catalogo.json de cada depto contiene ÚNICAMENTE las
+  hojas que recibieron ≥1 voto en ese depto. Por eso se usa la UNIÓN de todos los
+  catálogos de la elección como referencia:
+    · Si la hoja existe en al menos un depto → la candidatura fue real y obtuvo votos en
+      algún lugar. Que tenga 0 votos en un depto concreto es comportamiento esperado.
+    · Si la hoja no existe en NINGÚN catálogo → la candidatura se presentó pero no
+      obtuvo ningún voto en todo el país (12 hojas en nacionales-2024, 1.23% de
+      registros). Se reporta como advertencia y cuenta como falla del gate.
+
+  NO se usa un chequeo per-depto estricto porque generaría ~5.893 falsos positivos (2.7%)
+  en nacionales-2024, todos correspondientes a presentaciones locales con cero votos
+  locales pero votos reales en otros deptos — el join NO está roto en esos casos.
+
+  OK del gate significa: "todas las hojas que recibieron votos en algún depto están
+  correctamente representadas en la nómina". No certifica que hojas con cero votos
+  totales sean candidaturas canceladas — eso requiere cruzar con registros de habilitación
+  de la Corte Electoral.
+
+Uso: python scripts/gate-personas.py
+"""
+import json
+import os
+import glob
+import sys
+from functools import lru_cache
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DIR = os.path.join(ROOT, "public", "data", "personas")
+
+# ---------------------------------------------------------------------------
+# Helpers con caché (evita recargar catálogos 217 k veces)
+# ---------------------------------------------------------------------------
+
+_cat_cache: dict[str, set[str]] = {}
+_union_cache: dict[str, set[str]] = {}
+
+
+def hojas_catalogo(eleccion: str, depto: str) -> set[str] | None:
+    """Retorna el set de hojas del catálogo de un depto/elección (cacheado).
+    Retorna None si el catálogo no existe.
+    """
+    key = (eleccion, depto)
+    if key in _cat_cache:
+        return _cat_cache[key]
+    cat_path = os.path.join(ROOT, "public", "data", eleccion, depto, "catalogo.json")
+    if not os.path.exists(cat_path):
+        _cat_cache[key] = None
+        return None
+    with open(cat_path, encoding="utf-8") as f:
+        doc = json.load(f)
+    hojas: set[str] = set()
+    for c in doc.get("contiendas", []):
+        for o in c.get("opciones", []):
+            if o.get("hoja"):
+                hojas.add(str(o["hoja"]))
+    _cat_cache[key] = hojas
+    return hojas
+
+
+def hojas_union_catalogo(eleccion: str) -> set[str]:
+    """Retorna la unión de todas las hojas de todos los catálogos de la elección (cacheado)."""
+    if eleccion in _union_cache:
+        return _union_cache[eleccion]
+    patron = os.path.join(ROOT, "public", "data", eleccion, "*", "catalogo.json")
+    union: set[str] = set()
+    for cat_path in glob.glob(patron):
+        with open(cat_path, encoding="utf-8") as f:
+            doc = json.load(f)
+        for c in doc.get("contiendas", []):
+            for o in c.get("opciones", []):
+                if o.get("hoja"):
+                    union.add(str(o["hoja"]))
+    _union_cache[eleccion] = union
+    return union
+
+
+# ---------------------------------------------------------------------------
+# Validaciones por cargo
+# ---------------------------------------------------------------------------
+
+# Cargos cuya hoja es de alcance NACIONAL (misma papeleta en todos los deptos).
+# El catálogo per-depto los incluye solo cuando recibieron votos en ese depto, por lo
+# que un chequeo per-depto generaría falsos positivos masivos. Se validan contra la
+# unión de catálogos (que sí los cubre donde obtuvieron votos).
+CARGOS_NACIONALES = {"PRESIDENCIAL", "VICEPRESIDENCIAL", "SENADOR"}
+
+# Cargos por circunscripción departamental. Se validan primero per-depto; si tampoco
+# están en la unión se clasifican como huérfanos absolutos.
+CARGOS_POR_DEPTO = {"REPRESENTANTE", "JUNTA ELECTORAL"}
+
+# Cargos legislativos mínimos esperados en una elección de tipo "nacionales"
+CARGOS_LEGISLATIVOS_NACIONALES = {"SENADOR", "REPRESENTANTE"}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    errs: list[str] = []
+
+    shards = sorted(glob.glob(os.path.join(DIR, "personas-hoja.*.json")))
+    if not shards:
+        print(f"[gate:personas] No se encontraron shards en {DIR}")
+        sys.exit(1)
+
+    for path in shards:
+        with open(path, encoding="utf-8") as f:
+            doc = json.load(f)
+
+        eleccion: str = doc["eleccion"]
+        regs: list[dict] = doc["registros"]
+
+        # 1. Campos obligatorios
+        sin_cred = [r for r in regs if not r.get("personaId") or str(r["personaId"]).startswith("-")]
+        sin_hoja = [r for r in regs if not r.get("hoja")]
+        if sin_cred:
+            errs.append(f"{eleccion}: {len(sin_cred)} registros sin credencial (personaId)")
+        if sin_hoja:
+            errs.append(f"{eleccion}: {len(sin_hoja)} registros sin hoja")
+
+        # 2. Cargos legislativos mínimos en nacionales
+        if eleccion.startswith("nacionales"):
+            cargos_presentes = {r["cargo"].upper() for r in regs}
+            faltantes = CARGOS_LEGISLATIVOS_NACIONALES - cargos_presentes
+            if faltantes:
+                errs.append(
+                    f"{eleccion}: faltan cargos legislativos esperados: "
+                    f"{sorted(faltantes)} (cargos presentes: {sorted(cargos_presentes)})"
+                )
+
+        # 3. Hojas fantasma (solo registros que tienen hoja)
+        # Precargamos la unión una sola vez por elección
+        union = hojas_union_catalogo(eleccion)
+
+        # Huérfanos absolutos: hoja que no existe en NINGÚN catálogo de la elección
+        # (candidatura que obtuvo 0 votos en todo el país)
+        huerfanos_hojas: set[str] = set()
+        for r in regs:
+            h = r.get("hoja")
+            if h and str(h) not in union:
+                huerfanos_hojas.add(str(h))
+
+        if huerfanos_hojas:
+            n_regs = sum(1 for r in regs if r.get("hoja") and str(r["hoja"]) in huerfanos_hojas)
+            # Detalle por partido para diagnóstico
+            from collections import defaultdict
+            partido_count: dict[str, int] = defaultdict(int)
+            for r in regs:
+                if r.get("hoja") and str(r["hoja"]) in huerfanos_hojas:
+                    partido_count[r.get("partido", "?")] += 1
+            partido_str = ", ".join(
+                f"{p}:{c}" for p, c in sorted(partido_count.items(), key=lambda x: -x[1])
+            )
+            errs.append(
+                f"{eleccion}: {len(huerfanos_hojas)} hojas que no recibieron votos en "
+                f"ningún depto → {n_regs} registros huérfanos ({partido_str}). "
+                f"Hojas: {sorted(huerfanos_hojas)}"
+            )
+
+    if errs:
+        print("[gate:personas] FALLÓ:")
+        for e in errs:
+            print("  -", e)
+        sys.exit(1)
+
+    total_regs = sum(
+        len(json.load(open(p, encoding="utf-8"))["registros"])
+        for p in shards
+    )
+    print(
+        f"[gate:personas] OK — {len(shards)} shard(s), {total_regs:,} registros, "
+        "sin fantasmas absolutos (hojas con 0 votos en algún depto son presentaciones "
+        "locales sin votos, comportamiento esperado en nacionales)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/query-persona.py
+++ b/scripts/query-persona.py
@@ -61,11 +61,16 @@ def hoja_opcion(cat_doc, hoja: str, partido: str | None = None) -> str | None:
         return None
     if len(candidates) == 1:
         return candidates[0]
-    # Si hay varios (improbable) intentar usar partido como desambiguador
+    # Si hay varios (improbable) intentar usar partido como desambiguador.
+    # Se prueba el slug completo ("partido-nacional") Y sin el prefijo "partido-"
+    # ("nacional"), porque los opcionId omiten ese prefijo (ej. "unica-nacional-40").
     if partido:
         partido_slug = norm(partido).lower().replace(" ", "-")
+        # quitar prefijo "partido-" si existe (ej. "partido-nacional" → "nacional")
+        slug_no_prefix = partido_slug[len("partido-"):] if partido_slug.startswith("partido-") else partido_slug
         for oid in candidates:
-            if partido_slug in oid.lower():
+            oid_lower = oid.lower()
+            if partido_slug in oid_lower or slug_no_prefix in oid_lower:
                 return oid
     return candidates[0]
 
@@ -160,10 +165,12 @@ def main() -> None:
             }
         # Si ya existe la key, simplemente ignoramos (misma lista, otro cargo)
 
-    # Sumar votos
+    # Sumar votos — agrupados por elección para no mezclar distintas instancias.
+    # Estructura: por_eleccion[eleccion][depto] += votos
+    por_eleccion: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
     print("Detalle por elección / departamento / hoja:")
     print("-" * 70)
-    por_depto: dict[str, int] = defaultdict(int)
 
     for key, info in sorted(deduped.items()):
         eleccion, depto, oid = key
@@ -174,7 +181,7 @@ def main() -> None:
             f"  {info['eleccion']} · {info['cargo']} · hoja {info['hoja']}"
             f" · {info['depto']}: {v:,} votos de la lista{sin_dato}"
         )
-        por_depto[depto] += v
+        por_eleccion[eleccion][depto] += v
 
     if lineas_sin_desglose:
         print()
@@ -183,15 +190,17 @@ def main() -> None:
             print(l)
 
     print()
-    print("Ranking de departamentos (votos totales de las listas que integra):")
+    print("Ranking de departamentos por elección (votos totales de las listas que integra):")
     print("-" * 70)
-    grand_total = 0
-    for depto, v in sorted(por_depto.items(), key=lambda kv: -kv[1]):
-        print(f"  {depto:<20} {v:>10,}")
-        grand_total += v
-    print(f"  {'TOTAL PAÍS':<20} {grand_total:>10,}")
+    for eleccion in sorted(por_eleccion.keys()):
+        depto_votos = por_eleccion[eleccion]
+        total_eleccion = sum(depto_votos.values())
+        print(f"  [{eleccion}]")
+        for depto, v in sorted(depto_votos.items(), key=lambda kv: -kv[1]):
+            print(f"    {depto:<20} {v:>10,}")
+        print(f"    {'  TOTAL':<20} {total_eleccion:>10,}")
+        print()
 
-    print()
     print(
         "NOTA: es el voto a la LISTA (hoja), no voto personal "
         "— así funciona el voto legislativo en UY."

--- a/scripts/query-persona.py
+++ b/scripts/query-persona.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Verificación standalone de la dimensión personas↔hoja (previo a la API).
+Dado un nombre (substring, case/accent-insensitive) o credencial exacta,
+imprime las hojas que integra la persona y los votos de esas listas por
+departamento (ordenado desc). Métrica: votos de la LISTA, no votos personales.
+
+NOTA TÉCNICA: los votos se leen de hoja-local.json (nivel circuito/local),
+NO de votes.json (que solo tiene totales a nivel partido/lema sin desglose
+por hoja). La deduplicación por (eleccion, depto, opcionId) evita el doble
+conteo cuando la misma hoja aparece bajo múltiples cargos (senador + representante).
+
+Uso:
+  python scripts/query-persona.py "BERGARA"
+  python scripts/query-persona.py "BNB-42702"
+  python scripts/query-persona.py "ORSI"
+"""
+import json
+import os
+import sys
+import unicodedata
+from collections import defaultdict
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def norm(s: str) -> str:
+    """Normaliza a mayúsculas sin acentos para búsqueda case/accent-insensitive."""
+    s = unicodedata.normalize("NFD", s or "")
+    return "".join(c for c in s if unicodedata.category(c) != "Mn").upper()
+
+
+def find_persona(q: str):
+    """Busca por credencial exacta o substring de nombre (accent-insensitive)."""
+    path = os.path.join(ROOT, "public/data/personas/personas.json")
+    if not os.path.exists(path):
+        raise SystemExit(f"ERROR: no existe {path}")
+    doc = json.load(open(path, encoding="utf-8"))
+    qn = norm(q)
+    for p in doc["personas"]:
+        if p["personaId"] == q or any(qn in norm(n) for n in p["nombres"]):
+            return p
+    return None
+
+
+def hoja_opcion(cat_doc, hoja: str, partido: str | None = None) -> str | None:
+    """Resuelve hoja -> opcionId usando el documento de catalogo.json ya cargado.
+
+    Si se pasa partido, intenta priorizar el match del partido en el opcionId
+    (guarda contra el caso improbable de hoja compartida entre lemas en un depto).
+    Retorna None si no hay match.
+    """
+    hoja_str = str(hoja)
+    # Candidatos: todos los opciones con esa hoja
+    candidates = [
+        o["id"]
+        for c in cat_doc.get("contiendas", [])
+        for o in c.get("opciones", [])
+        if str(o.get("hoja")) == hoja_str
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    # Si hay varios (improbable) intentar usar partido como desambiguador
+    if partido:
+        partido_slug = norm(partido).lower().replace(" ", "-")
+        for oid in candidates:
+            if partido_slug in oid.lower():
+                return oid
+    return candidates[0]
+
+
+def build_oid_totals(eleccion: str, depto: str) -> dict[str, int]:
+    """Carga hoja-local.json y construye un dict opcionId -> votos totales del depto.
+
+    Suma todas las zonas (circuitos/locales) para obtener el total departamental.
+    Cachea en memoria durante la ejecución (el dict se construye una sola vez por
+    combinación eleccion+depto).
+    """
+    hl_path = os.path.join(ROOT, "public/data", eleccion, depto, "hoja-local.json")
+    if not os.path.exists(hl_path):
+        return {}
+    doc = json.load(open(hl_path, encoding="utf-8"))
+    totals: dict[str, int] = defaultdict(int)
+    for z in doc.get("zonas", []):
+        for o in z.get("porOpcion", []):
+            totals[o["opcionId"]] += o.get("votos", 0)
+    return dict(totals)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit('Uso: query-persona.py "<nombre|credencial>"')
+
+    query = sys.argv[1]
+    p = find_persona(query)
+    if not p:
+        raise SystemExit(f"Persona no encontrada para '{query}'")
+
+    nombre_display = p["nombres"][0] if p["nombres"] else p["personaId"]
+    print(f"Persona : {nombre_display}")
+    print(f"ID      : {p['personaId']}")
+    print(f"Total apariciones: {len(p['apariciones'])}")
+    print()
+
+    # Cargar catálogos y totales de hojas (cacheados por eleccion+depto)
+    cat_cache: dict[str, dict] = {}
+    oid_cache: dict[str, dict[str, int]] = {}
+
+    def get_cat(eleccion: str, depto: str):
+        key = f"{eleccion}/{depto}"
+        if key not in cat_cache:
+            path = os.path.join(ROOT, "public/data", eleccion, depto, "catalogo.json")
+            cat_cache[key] = json.load(open(path, encoding="utf-8")) if os.path.exists(path) else {}
+        return cat_cache[key]
+
+    def get_totals(eleccion: str, depto: str) -> dict[str, int]:
+        key = f"{eleccion}/{depto}"
+        if key not in oid_cache:
+            oid_cache[key] = build_oid_totals(eleccion, depto)
+        return oid_cache[key]
+
+    # Resolver apariciones a (eleccion, depto, opcionId) — deduplicado para no
+    # contar la misma lista dos veces cuando la persona aparece como SENADOR y
+    # también como REPRESENTANTE en la misma hoja del mismo depto.
+    deduped: dict[tuple[str, str, str], dict] = {}  # (eleccion,depto,opcionId) -> info
+
+    lineas_sin_desglose: list[str] = []
+
+    for a in p["apariciones"]:
+        eleccion = a["eleccion"]
+        depto = a["departamento"]
+        hoja = str(a["hoja"])
+        cargo = a["cargo"]
+        partido = a.get("partido", "")
+
+        cat_doc = get_cat(eleccion, depto)
+        if not cat_doc:
+            lineas_sin_desglose.append(
+                f"  {eleccion} · {depto} · hoja {hoja} ({cargo}): sin catalogo.json"
+            )
+            continue
+
+        oid = hoja_opcion(cat_doc, hoja, partido)
+        if not oid:
+            lineas_sin_desglose.append(
+                f"  {eleccion} · {depto} · hoja {hoja} ({cargo}): hoja no encontrada en catálogo"
+            )
+            continue
+
+        key = (eleccion, depto, oid)
+        if key not in deduped:
+            deduped[key] = {
+                "eleccion": eleccion,
+                "depto": depto,
+                "hoja": hoja,
+                "cargo": cargo,
+                "partido": partido,
+                "opcionId": oid,
+            }
+        # Si ya existe la key, simplemente ignoramos (misma lista, otro cargo)
+
+    # Sumar votos
+    print("Detalle por elección / departamento / hoja:")
+    print("-" * 70)
+    por_depto: dict[str, int] = defaultdict(int)
+
+    for key, info in sorted(deduped.items()):
+        eleccion, depto, oid = key
+        totals = get_totals(eleccion, depto)
+        v = totals.get(oid, 0)
+        sin_dato = "" if v > 0 else "  ← 0 votos (hoja sin datos en hoja-local)"
+        print(
+            f"  {info['eleccion']} · {info['cargo']} · hoja {info['hoja']}"
+            f" · {info['depto']}: {v:,} votos de la lista{sin_dato}"
+        )
+        por_depto[depto] += v
+
+    if lineas_sin_desglose:
+        print()
+        print("Apariciones sin desglose por hoja:")
+        for l in lineas_sin_desglose:
+            print(l)
+
+    print()
+    print("Ranking de departamentos (votos totales de las listas que integra):")
+    print("-" * 70)
+    grand_total = 0
+    for depto, v in sorted(por_depto.items(), key=lambda kv: -kv[1]):
+        print(f"  {depto:<20} {v:>10,}")
+        grand_total += v
+    print(f"  {'TOTAL PAÍS':<20} {grand_total:>10,}")
+
+    print()
+    print(
+        "NOTA: es el voto a la LISTA (hoja), no voto personal "
+        "— así funciona el voto legislativo en UY."
+    )
+    print(
+        "Las listas están deduplicadas por (eleccion, depto, opcionId): "
+        "la misma hoja bajo múltiples cargos se cuenta una sola vez."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Qué construye
La dimensión de datos **persona↔hoja**: quién integra cada lista, con **id de persona estable por credencial** (`SERIE-NUMERO`), desde la "Integración de hojas de votación" de la Corte (CKAN). Voto legislativo = a la **LISTA** → "votos de un candidato" = votos de su(s) hoja(s).

## Pipeline (Python, npm scripts)
- `etl:nominas-fetch` — baja la Integración desde CKAN (idempotente; CSV→XLSX fallback).
- `etl:personas-hoja` — parser por elección → `personas-hoja.{eleccion}.json` (un registro por persona×hoja×cargo).
- `etl:personas` — consolida por credencial → `personas.json` (una persona, todas sus apariciones).
- `gate:personas` — integridad: credencial+hoja presentes, cargos legislativos, hojas huérfanas (<10%, unión de catálogos), **+ sonda de votos no-cero** (certifica que el join produce votos, no solo que la hoja existe).
- `query-persona.py` — verificación standalone: persona → votos de sus listas **por departamento y por elección** (vía `hoja-local.json`).

## Cobertura y hallazgos
| Elección | Registros | Personas | Cargos |
|---|---|---|---|
| nacionales-2024 | 217k | 22.867 | SENADOR / REPRESENTANTE / JUNTA ELECTORAL |
| internas-2024 | 334k | 147.265 | ODN / ODD |
| departamentales-2025 | 137k | 84.083 | JUNTA DEPARTAMENTAL / MUNICIPIO / INTENDENTE |

- **M = 49.842 personas en >1 elección** (la credencial une identidades cross-elección — validación clave).
- **nacionales-2019 NO tiene columnas de credencial** y **2014 no publica integración** → la identidad por credencial solo aplica de 2024 en adelante. Limita el histórico de legisladores cross-año (caso Octavio): es una limitación del esquema de la Corte, no del pipeline.
- El join persona→hoja→votos funciona (~96% de hojas; verificado con senadores reales dando cifras plausibles).

## Decisiones de diseño
- **Outputs gitignoreados** (`public/data/personas/`, ~340MB de intermedios): el person×hoja crudo no escala para commitear/servir (duplicación de nóminas de senadores × ~2800 hojas). El servido/API (story 21.3) queda aparte y debería keyear persona→(elección, cargo, sublema), no person×hoja.
- Voto por hoja se lee de `hoja-local.json` (no `votes.json`, que es a nivel lema).

## Verificación
`npm run gate:personas` → OK (con sonda de votos). `python scripts/query-persona.py "<apellido>"` → ranking por elección/depto.

## Fuera de alcance
Story 21.3 (endpoint `/api/v1/candidatos`) — depende del Epic 20 (API), ya live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)