### PR TITLE
feat(api-docs): doc alineada con la app + ejemplos; default = balotaje-2024 nacional

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,8 @@ export default defineConfig({
   // Redirect de raíz INSTANTÁNEO: el adapter Vercel lo emite como redirect HTTP de plataforma
   // (no una página HTML con meta-refresh, que mostraba el "flash" de redirección).
   redirects: {
-    '/': '/internas-2024/montevideo',
+    // Landing = última elección nacional (balotaje 2024) en su vista nacional.
+    '/': '/balotaje-2024',
   },
   // Deploy en Vercel. El adapter es la fuente de verdad del deploy (reemplaza vercel.json).
   adapter: vercel(),

--- a/public/api/v1/openapi.json
+++ b/public/api/v1/openapi.json
@@ -3,19 +3,181 @@
   "info": {
     "title": "API pública — Mapa Electoral de Uruguay",
     "version": "1.0.0",
-    "description": "Datos electorales de Uruguay (resultados, catálogos, geometría). Read-only, CORS abierto, cache inmutable. El descubrimiento vive en /api/v1/index.json. Toda la superficie cuelga de /api/v1/. Fuente: Corte Electoral. Datos abiertos con atribución.",
+    "description": "Datos electorales de Uruguay (resultados, catálogos, geometría y candidatos). Read-only, CORS abierto (`Access-Control-Allow-Origin: *`), cache inmutable. El descubrimiento vive en `/api/v1/index.json`; toda la superficie cuelga de `/api/v1/`. Los resultados y la geometría se sirven desde archivos estáticos vía rewrites. Fuente: Corte Electoral del Uruguay — datos abiertos con atribución.",
     "license": { "name": "Datos abiertos con atribución a la Corte Electoral" }
   },
   "servers": [{ "url": "https://uruguay-electoral-map.vercel.app" }],
+  "tags": [
+    { "name": "Descubrimiento", "description": "Índices para navegar la API." },
+    { "name": "Resultados", "description": "Votos por zona y geometría por departamento." },
+    { "name": "Candidatos", "description": "Personas candidatas y votos de sus listas (Epic 21)." }
+  ],
   "paths": {
-    "/api/v1/index.json": { "get": { "summary": "Descubrimiento (elecciones, departamentos, links)", "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/elections.json": { "get": { "summary": "Lista de elecciones", "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/elections/{eleccion}.json": { "get": { "summary": "Detalle de una elección (deptos + recursos)", "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/dumps/{eleccion}.ndjson": { "get": { "summary": "Dump NDJSON por elección", "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/results/{eleccion}/{departamento}/votes.json": { "get": { "summary": "Resultados por zona", "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" } }, { "name": "departamento", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/geo/{departamento}/{nivel}.topo.json": { "get": { "summary": "Geometría TopoJSON", "parameters": [{ "name": "departamento", "in": "path", "required": true, "schema": { "type": "string" } }, { "name": "nivel", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/candidatos/index.json": { "get": { "summary": "Índice de búsqueda de legisladores (senadores y representantes)", "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/candidatos/legisladores.json": { "get": { "summary": "Legisladores con resultados: votos de sus listas por departamento y elección (métrica: voto a la lista, no personal)", "responses": { "200": { "description": "OK" } } } },
-    "/api/v1/candidatos/personas-index.json": { "get": { "summary": "Índice slim de todas las personas candidatas (sin resultados; resultados solo para legisladores)", "responses": { "200": { "description": "OK" } } } }
+    "/api/v1/index.json": {
+      "get": {
+        "tags": ["Descubrimiento"],
+        "summary": "Índice raíz",
+        "description": "Punto de entrada: links a elecciones, candidatos, docs y OpenAPI; lista de departamentos y elecciones disponibles.",
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "version": "v1",
+          "fuente": "Corte Electoral del Uruguay (catalogodatos.gub.uy)",
+          "licencia": "Datos abiertos con atribución a la Corte Electoral.",
+          "docs": "/api/v1/docs",
+          "openapi": "/api/v1/openapi.json",
+          "elections": "/api/v1/elections.json",
+          "candidatos": "/api/v1/candidatos/index.json",
+          "departamentos": ["artigas", "canelones", "montevideo", "salto", "…"],
+          "elecciones": ["balotaje-2024", "nacionales-2024", "departamentales-2025", "…"]
+        } } } } }
+      }
+    },
+    "/api/v1/elections.json": {
+      "get": {
+        "tags": ["Descubrimiento"],
+        "summary": "Lista de elecciones",
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "elecciones": [
+            { "id": "nacionales-2024", "departamentos": ["artigas", "canelones", "montevideo", "…"], "detalle": "/api/v1/elections/nacionales-2024.json" },
+            { "id": "balotaje-2024", "departamentos": ["artigas", "canelones", "montevideo", "…"], "detalle": "/api/v1/elections/balotaje-2024.json" }
+          ]
+        } } } } }
+      }
+    },
+    "/api/v1/elections/{eleccion}.json": {
+      "get": {
+        "tags": ["Descubrimiento"],
+        "summary": "Detalle de una elección (departamentos + recursos)",
+        "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" }, "example": "nacionales-2024" }],
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "id": "nacionales-2024",
+          "departamentos": [
+            {
+              "id": "montevideo",
+              "results": {
+                "catalogo": "/api/v1/results/nacionales-2024/montevideo/catalogo.json",
+                "votes": "/api/v1/results/nacionales-2024/montevideo/votes.json",
+                "hoja-local": "/api/v1/results/nacionales-2024/montevideo/hoja-local.json"
+              },
+              "geo": {
+                "zona.topo": "/api/v1/geo/montevideo/zona.topo.json",
+                "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json"
+              }
+            }
+          ]
+        } } } } }
+      }
+    },
+    "/api/v1/results/{eleccion}/{departamento}/votes.json": {
+      "get": {
+        "tags": ["Resultados"],
+        "summary": "Resultados por zona",
+        "description": "Votos por opción en cada zona geográfica del departamento, con el ganador, los válidos y los votos no partidarios (en blanco / anulados / observados).",
+        "parameters": [
+          { "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" }, "example": "balotaje-2024" },
+          { "name": "departamento", "in": "path", "required": true, "schema": { "type": "string" }, "example": "montevideo" }
+        ],
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "eleccionId": "balotaje-2024",
+          "departamento": "montevideo",
+          "nivel": "zona",
+          "escrutinio": "definitivo",
+          "tipo": "balotaje",
+          "zonas": [
+            {
+              "geoId": "Ciudad Vieja",
+              "ganadorOpcionId": "frente-amplio",
+              "validos": 22729,
+              "porOpcion": [
+                { "opcionId": "frente-amplio", "votos": 15195 },
+                { "opcionId": "nacional", "votos": 7534 }
+              ],
+              "noPartidarios": { "enBlanco": 309, "anulados": 595, "observados": 157 }
+            }
+          ]
+        } } } } }
+      }
+    },
+    "/api/v1/geo/{departamento}/{nivel}.topo.json": {
+      "get": {
+        "tags": ["Resultados"],
+        "summary": "Geometría TopoJSON",
+        "description": "Geometría del departamento en formato TopoJSON para el nivel pedido (zona/barrio, circuito, local, serie, localidad). Los `geoId` cruzan con los de `votes.json`.",
+        "parameters": [
+          { "name": "departamento", "in": "path", "required": true, "schema": { "type": "string" }, "example": "montevideo" },
+          { "name": "nivel", "in": "path", "required": true, "schema": { "type": "string" }, "example": "zona" }
+        ],
+        "responses": { "200": { "description": "OK (objeto TopoJSON: { type: 'Topology', objects, arcs })", "content": { "application/json": { "example": {
+          "type": "Topology",
+          "objects": { "zona": { "type": "GeometryCollection", "geometries": ["…"] } },
+          "arcs": ["…"]
+        } } } } }
+      }
+    },
+    "/api/v1/dumps/{eleccion}.ndjson": {
+      "get": {
+        "tags": ["Resultados"],
+        "summary": "Dump NDJSON por elección",
+        "description": "Una línea JSON por (departamento × zona × opción) para procesamiento masivo.",
+        "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string" }, "example": "nacionales-2024" }],
+        "responses": { "200": { "description": "OK", "content": { "application/x-ndjson": { "example": "{\"eleccion\":\"nacionales-2024\",\"departamento\":\"montevideo\",\"zona\":\"Ciudad Vieja\",\"opcionId\":\"frente-amplio\",\"votos\":12345}\n{\"eleccion\":\"nacionales-2024\",\"departamento\":\"montevideo\",\"zona\":\"Ciudad Vieja\",\"opcionId\":\"nacional\",\"votos\":6789}" } } } }
+      }
+    },
+    "/api/v1/candidatos/index.json": {
+      "get": {
+        "tags": ["Candidatos"],
+        "summary": "Índice de legisladores",
+        "description": "Búsqueda de los 17.665 legisladores (senadores y representantes). El detalle con resultados está en `/api/v1/candidatos/legisladores.json`.",
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "total": 17665,
+          "fuente": "Corte Electoral del Uruguay — Integración de hojas de votación (catalogodatos.gub.uy).",
+          "metrica": "votos de la(s) lista(s) que integra la persona (hoja), por departamento. No es voto personal: el voto legislativo en Uruguay es a la LISTA.",
+          "detalle": "/api/v1/candidatos/legisladores.json",
+          "candidatos": [
+            { "id": "BNB-42702", "nombre": "MARIO ESTEBAN BERGARA DUQUE", "cargos": ["REPRESENTANTE", "SENADOR"], "partidos": ["FRENTE AMPLIO"], "elecciones": ["nacionales-2024"] }
+          ]
+        } } } } }
+      }
+    },
+    "/api/v1/candidatos/legisladores.json": {
+      "get": {
+        "tags": ["Candidatos"],
+        "summary": "Legisladores con resultados",
+        "description": "Para cada legislador, los votos de las listas que integra **por departamento y elección**. Métrica: voto a la LISTA (hoja), no voto personal — así funciona el voto legislativo en Uruguay.",
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "total": 17665,
+          "metrica": "votos de la(s) lista(s) que integra la persona (hoja), por departamento.",
+          "candidatos": [
+            {
+              "id": "BNB-42702",
+              "nombres": ["MARIO ESTEBAN BERGARA DUQUE"],
+              "cargos": ["REPRESENTANTE", "SENADOR"],
+              "partidos": ["FRENTE AMPLIO"],
+              "elecciones": ["nacionales-2024"],
+              "candidaturas": [{ "eleccion": "nacionales-2024", "cargo": "SENADOR", "partido": "FRENTE AMPLIO", "sublema": "UNIDAD PARA LOS CAMBIOS" }],
+              "resultados": {
+                "nacionales-2024": {
+                  "porDepto": { "montevideo": 30920, "colonia": 13996, "canelones": 13308, "…": 0 },
+                  "total": 90784
+                }
+              }
+            }
+          ]
+        } } } } }
+      }
+    },
+    "/api/v1/candidatos/personas-index.json": {
+      "get": {
+        "tags": ["Candidatos"],
+        "summary": "Índice de todas las personas candidatas",
+        "description": "Cobertura/descubrimiento de las 196.834 personas candidatas (sin resultados; los resultados por departamento solo están para legisladores en `legisladores.json`).",
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "total": 196834,
+          "nota": "Resultados (por depto) solo para legisladores en legisladores.json.",
+          "personas": [
+            { "id": "BNB-42702", "nombre": "MARIO ESTEBAN BERGARA DUQUE", "cargos": ["INTENDENTE", "JUNTA DEPARTAMENTAL", "REPRESENTANTE", "SENADOR"], "elecciones": ["departamentales-2025", "internas-2024", "nacionales-2024"] }
+          ]
+        } } } } }
+      }
+    }
   }
 }

--- a/src/pages/api/v1/docs.astro
+++ b/src/pages/api/v1/docs.astro
@@ -1,15 +1,165 @@
 ---
-// Docs de la API pública (Scalar UI sobre /api/v1/openapi.json). Estática (prerender por defecto).
+/**
+ * Docs de la API pública (Scalar UI sobre /api/v1/openapi.json). Estática.
+ * Alineada con la estética de la app: tokens de color (light/dark vía
+ * prefers-color-scheme), fuentes Inter/Source Serif 4, header con vuelta al
+ * mapa y footer (Sello). El tema de Scalar se mapea a las variables de la app.
+ */
+import '../../../styles/global.css';
 ---
+
 <!doctype html>
-<html lang="es">
+<html lang="es-UY">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <title>API pública — Mapa Electoral de Uruguay</title>
+    <meta
+      name="description"
+      content="Documentación de la API pública de datos electorales de Uruguay: resultados, geometría y candidatos. Read-only, CORS abierto, datos abiertos de la Corte Electoral."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap"
+      rel="stylesheet"
+    />
+    <style is:global>
+      /* Mapea las variables de Scalar a los tokens de la app (light). */
+      :root {
+        --scalar-font: 'Inter', system-ui, sans-serif;
+        --scalar-font-code: ui-monospace, 'SF Mono', 'Cascadia Code', monospace;
+        --scalar-color-1: var(--color-ink);
+        --scalar-color-2: var(--color-ink-soft);
+        --scalar-color-3: var(--color-ink-muted);
+        --scalar-color-accent: var(--color-accent);
+        --scalar-background-1: var(--color-paper);
+        --scalar-background-2: var(--color-surface-2);
+        --scalar-background-3: var(--color-bg);
+        --scalar-background-accent: var(--color-highlight);
+        --scalar-border-color: var(--color-border);
+        --scalar-color-green: #15803d;
+        --scalar-radius: 0.5rem;
+      }
+
+      html,
+      body {
+        margin: 0;
+        background: var(--color-bg);
+        color: var(--color-ink);
+        font-family: 'Inter', system-ui, sans-serif;
+      }
+
+      /* Header de la doc — mismo lenguaje visual que el masthead de la app. */
+      .api-header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.85rem 1.25rem;
+        background: var(--color-paper);
+        border-bottom: 1px solid var(--color-border);
+        position: sticky;
+        top: 0;
+        z-index: 20;
+      }
+      .api-header__home {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: var(--color-ink-muted);
+        text-decoration: none;
+        padding: 0.4rem 0.7rem;
+        border: 1px solid var(--color-border-strong);
+        border-radius: 0.5rem;
+        white-space: nowrap;
+        transition: color 0.15s, border-color 0.15s, background 0.15s;
+      }
+      .api-header__home:hover {
+        color: var(--color-ink);
+        border-color: var(--color-ink-muted);
+        background: var(--color-surface-2);
+      }
+      .api-header__titles {
+        display: flex;
+        flex-direction: column;
+        line-height: 1.15;
+      }
+      .api-header__kicker {
+        font-size: 0.7rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-ink-faint);
+      }
+      .api-header__title {
+        margin: 0;
+        font-family: 'Source Serif 4', Georgia, serif;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: var(--color-ink);
+      }
+      .api-header__badge {
+        margin-left: auto;
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--color-accent);
+        border: 1px solid var(--color-border-strong);
+        border-radius: 999px;
+        padding: 0.15rem 0.6rem;
+      }
+
+      .api-footer {
+        font-size: 0.75rem;
+        color: var(--color-ink-faint);
+        text-align: center;
+        padding: 1rem 0.75rem 1.5rem;
+        background: var(--color-bg);
+        border-top: 1px solid var(--color-border);
+      }
+      .api-footer a {
+        color: var(--color-ink-muted);
+        text-underline-offset: 2px;
+      }
+
+      @media (max-width: 560px) {
+        .api-header__badge { display: none; }
+        .api-header__title { font-size: 1rem; }
+      }
+    </style>
   </head>
   <body>
-    <script id="api-reference" data-url="/api/v1/openapi.json"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <header class="api-header">
+      <a class="api-header__home" href="/" aria-label="Volver al mapa electoral">
+        <span aria-hidden="true">←</span> Volver al mapa
+      </a>
+      <div class="api-header__titles">
+        <span class="api-header__kicker">Mapa Electoral de Uruguay</span>
+        <h1 class="api-header__title">API pública v1</h1>
+      </div>
+      <span class="api-header__badge">read-only · CORS abierto</span>
+    </header>
+
+    <main id="main-content">
+      <script is:inline id="api-reference" data-url="/api/v1/openapi.json"></script>
+      <script is:inline>
+        // Scalar: tema 'none' (usa nuestras variables CSS) y dark mode siguiendo el SO.
+        const el = document.getElementById('api-reference');
+        el.dataset.configuration = JSON.stringify({
+          theme: 'none',
+          layout: 'modern',
+          darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+          hideDarkModeToggle: false,
+          metaData: { title: 'API pública — Mapa Electoral de Uruguay' },
+        });
+      </script>
+      <script is:inline src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    </main>
+
+    <footer class="api-footer">
+      Fuente:&nbsp;<a href="https://www.corteelectoral.gub.uy/" target="_blank" rel="noopener">Corte Electoral Uruguay</a>
+      &nbsp;·&nbsp;Datos abiertos con atribución&nbsp;·&nbsp;<a href="/">volver al mapa</a>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Qué cambia
**1. Página de docs (`/api/v1/docs`) alineada con la app.** Antes era un embed pelado de Scalar. Ahora:
- Header con **"← Volver al mapa"** + título de la app ("Mapa Electoral de Uruguay" / "API pública v1" en serif Source Serif 4) + badge "read-only · CORS abierto" en color de acento.
- Footer con fuente (Corte Electoral) + vuelta al mapa.
- Tema de Scalar mapeado a los **tokens de la app** (`--scalar-*` → `--color-*`), con **light/dark siguiendo el SO** (vía la misma indirección de tokens que el resto de la app).
- Fuentes Inter (body) + Source Serif 4 (títulos).

**2. Ejemplos en el OpenAPI.** Cada endpoint ahora tiene ejemplo de respuesta real (recortado) + tags + descripciones → Scalar muestra ejemplos navegables (Descubrimiento / Resultados / Candidatos).

**3. Default landing** pasa de `/internas-2024/montevideo` a **`/balotaje-2024`** (última elección nacional, vista nacional de Uruguay).

## Verificación (local, astro dev + Playwright)
- Light y dark renderizan alineados con la app (capturas adjuntas en el chat).
- Ejemplos visibles por endpoint.
- `/` redirige a `/balotaje-2024/` ("Uruguay — Balotaje 2024 | Mapa nacional").
- `astro check`: 0 errores. `gate:api`: OK.

> Nota: si el default preferido es `departamentales-2025` (la más reciente en fecha) en vez de `balotaje-2024`, es cambiar una línea en astro.config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)