### PR TITLE
fix(ui): botón Compartir overflow + sacar 'Epic' de textos visibles

### DIFF
--- a/public/api/v1/openapi.json
+++ b/public/api/v1/openapi.json
@@ -10,7 +10,7 @@
   "tags": [
     { "name": "Descubrimiento", "description": "Índices para navegar la API." },
     { "name": "Resultados", "description": "Votos por zona y geometría por departamento." },
-    { "name": "Candidatos", "description": "Personas candidatas y votos de sus listas (Epic 21)." }
+    { "name": "Candidatos", "description": "Personas candidatas y votos de las listas que integran (legisladores)." }
   ],
   "paths": {
     "/api/v1/index.json": {

--- a/src/api/api-contract.test.ts
+++ b/src/api/api-contract.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests de contrato de la API pública v1 (Epics 20 + 21.3).
+ * Tests de contrato de la API pública v1.
  *
  * Validan los artefactos servidos bajo public/api/v1/** (y los /data detrás de los
  * rewrites) leyéndolos del disco: forma (JSON-Schema), integridad referencial
@@ -106,7 +106,7 @@ describe('API v1 — votos servidos (forma)', () => {
   });
 });
 
-describe('API v1 — candidatos (Epic 21.3)', () => {
+describe('API v1 — candidatos', () => {
   const index = read('public/api/v1/candidatos/index.json');
   const legis = read('public/api/v1/candidatos/legisladores.json');
   const personas = read('public/api/v1/candidatos/personas-index.json');

--- a/src/components/share/ShareButton.vue
+++ b/src/components/share/ShareButton.vue
@@ -68,6 +68,10 @@ async function handleShare(): Promise<void> {
   cursor: pointer;
   transition: background 0.12s, color 0.12s, border-color 0.12s;
   white-space: nowrap;
+  /* No comprimirse en el masthead (flex space-between): con títulos/elecciones
+     largos —p. ej. la vista nacional— el botón se achicaba y el texto se
+     desbordaba de su caja. El lado del título absorbe el ajuste (wrap). */
+  flex-shrink: 0;
 }
 .share-btn:hover {
   background: var(--color-surface-2);


### PR DESCRIPTION
## Qué arregla
**1. Overflow del botón Compartir.** En el masthead (flex `space-between`), con elecciones de nombre largo —p. ej. la vista nacional "Elecciones Departamentales y Municipales 2025 — mapa nacional"— el botón se comprimía (~72px, medido) y el texto "Compartir" se desbordaba de su caja. Fix: `flex-shrink: 0` en `.share-btn` → el botón mantiene su ancho y el lado del título absorbe el ajuste (wrap).

**2. "Epic" en textos visibles.** La descripción del tag "Candidatos" del OpenAPI decía "(Epic 21)" (término interno de planificación, visible en la doc Scalar). Reemplazado por texto de dominio. Misma limpieza en el test que agregué.

## Verificación
- `gate:api` OK · 13 tests de contrato OK.
- El overflow se reverifica en producción tras merge (medición del ancho del botón en la vista nacional, móvil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)