### PR TITLE
feat(api): exponer municipales (2025/2020) + alcaldes + Concejos en la API v1

### DIFF
--- a/public/api/v1/dumps/municipales-2020.manifest.json
+++ b/public/api/v1/dumps/municipales-2020.manifest.json
@@ -1,0 +1,15 @@
+{
+ "eleccion": "municipales-2020",
+ "registros": 433,
+ "formato": "ndjson",
+ "campos": [
+  "eleccion",
+  "departamento",
+  "geoId",
+  "opcionId",
+  "votos",
+  "validos"
+ ],
+ "fuente": "Corte Electoral del Uruguay",
+ "version": "v1"
+}

--- a/public/api/v1/dumps/municipales-2020.ndjson
+++ b/public/api/v1/dumps/municipales-2020.ndjson
@@ -1,0 +1,433 @@
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "frente-amplio", "votos": 30273, "validos": 44972}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "partido-independiente", "votos": 13816, "validos": 44972}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "partido-verde-animalista", "votos": 497, "validos": 44972}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "asamblea-popular", "votos": 386, "validos": 44972}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "frente-amplio", "votos": 23247, "validos": 44306}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "partido-independiente", "votos": 20752, "validos": 44306}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "asamblea-popular", "votos": 307, "validos": 44306}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "frente-amplio", "votos": 22432, "validos": 42319}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "partido-independiente", "votos": 19616, "validos": 42319}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "asamblea-popular", "votos": 271, "validos": 42319}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "partido-independiente", "votos": 41496, "validos": 64565}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "frente-amplio", "votos": 22787, "validos": 64565}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "asamblea-popular", "votos": 282, "validos": 64565}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "frente-amplio", "votos": 17044, "validos": 33538}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "partido-independiente", "votos": 16261, "validos": 33538}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "asamblea-popular", "votos": 233, "validos": 33538}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "partido-independiente", "votos": 30891, "validos": 53111}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "frente-amplio", "votos": 21998, "validos": 53111}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "asamblea-popular", "votos": 222, "validos": 53111}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "partido-independiente", "votos": 18502, "validos": 34872}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "frente-amplio", "votos": 16158, "validos": 34872}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "asamblea-popular", "votos": 212, "validos": 34872}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "frente-amplio", "votos": 20722, "validos": 36007}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "partido-independiente", "votos": 14998, "validos": 36007}
+{"eleccion": "municipales-2020", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "asamblea-popular", "votos": 287, "validos": 36007}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "18 de Mayo", "opcionId": "frente-amplio", "votos": 3357, "validos": 6267}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "18 de Mayo", "opcionId": "partido-nacional", "votos": 1528, "validos": 6267}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "18 de Mayo", "opcionId": "partido-colorado", "votos": 1176, "validos": 6267}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "18 de Mayo", "opcionId": "cabildo-abierto", "votos": 179, "validos": 6267}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "18 de Mayo", "opcionId": "asamblea-popular", "votos": 27, "validos": 6267}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Aguas Corrientes", "opcionId": "frente-amplio", "votos": 478, "validos": 851}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Aguas Corrientes", "opcionId": "partido-nacional", "votos": 301, "validos": 851}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Aguas Corrientes", "opcionId": "partido-colorado", "votos": 72, "validos": 851}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Atlántida", "opcionId": "frente-amplio", "votos": 3017, "validos": 5903}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Atlántida", "opcionId": "partido-nacional", "votos": 2532, "validos": 5903}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Atlántida", "opcionId": "partido-colorado", "votos": 283, "validos": 5903}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Atlántida", "opcionId": "cabildo-abierto", "votos": 71, "validos": 5903}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Barros Blancos", "opcionId": "frente-amplio", "votos": 8067, "validos": 12576}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Barros Blancos", "opcionId": "partido-nacional", "votos": 3567, "validos": 12576}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Barros Blancos", "opcionId": "cabildo-abierto", "votos": 484, "validos": 12576}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Barros Blancos", "opcionId": "partido-colorado", "votos": 458, "validos": 12576}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Canelones", "opcionId": "frente-amplio", "votos": 7494, "validos": 12352}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Canelones", "opcionId": "partido-nacional", "votos": 3307, "validos": 12352}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Canelones", "opcionId": "partido-colorado", "votos": 1050, "validos": 12352}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Canelones", "opcionId": "cabildo-abierto", "votos": 431, "validos": 12352}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Canelones", "opcionId": "asamblea-popular", "votos": 70, "validos": 12352}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Ciudad de la Costa", "opcionId": "frente-amplio", "votos": 22702, "validos": 31870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Ciudad de la Costa", "opcionId": "partido-nacional", "votos": 6831, "validos": 31870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Ciudad de la Costa", "opcionId": "cabildo-abierto", "votos": 1357, "validos": 31870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Ciudad de la Costa", "opcionId": "partido-colorado", "votos": 784, "validos": 31870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Ciudad de la Costa", "opcionId": "asamblea-popular", "votos": 196, "validos": 31870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Colonia Nicolich", "opcionId": "frente-amplio", "votos": 2925, "validos": 4167}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Colonia Nicolich", "opcionId": "partido-nacional", "votos": 1053, "validos": 4167}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Colonia Nicolich", "opcionId": "cabildo-abierto", "votos": 149, "validos": 4167}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Colonia Nicolich", "opcionId": "partido-colorado", "votos": 40, "validos": 4167}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Empalme Olmos", "opcionId": "frente-amplio", "votos": 2581, "validos": 3816}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Empalme Olmos", "opcionId": "partido-nacional", "votos": 1008, "validos": 3816}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Empalme Olmos", "opcionId": "cabildo-abierto", "votos": 122, "validos": 3816}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Empalme Olmos", "opcionId": "partido-colorado", "votos": 105, "validos": 3816}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Floresta", "opcionId": "frente-amplio", "votos": 1891, "validos": 3871}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Floresta", "opcionId": "partido-nacional", "votos": 1602, "validos": 3871}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Floresta", "opcionId": "partido-colorado", "votos": 283, "validos": 3871}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Floresta", "opcionId": "cabildo-abierto", "votos": 95, "validos": 3871}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Paz", "opcionId": "frente-amplio", "votos": 7620, "validos": 10532}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Paz", "opcionId": "partido-nacional", "votos": 2477, "validos": 10532}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Paz", "opcionId": "partido-colorado", "votos": 268, "validos": 10532}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "La Paz", "opcionId": "cabildo-abierto", "votos": 167, "validos": 10532}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Las Piedras", "opcionId": "frente-amplio", "votos": 15766, "validos": 27769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Las Piedras", "opcionId": "partido-nacional", "votos": 9993, "validos": 27769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Las Piedras", "opcionId": "partido-colorado", "votos": 1286, "validos": 27769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Las Piedras", "opcionId": "cabildo-abierto", "votos": 664, "validos": 27769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Las Piedras", "opcionId": "asamblea-popular", "votos": 60, "validos": 27769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Los Cerrillos", "opcionId": "frente-amplio", "votos": 2070, "validos": 4459}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Los Cerrillos", "opcionId": "partido-nacional", "votos": 1933, "validos": 4459}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Los Cerrillos", "opcionId": "cabildo-abierto", "votos": 294, "validos": 4459}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Los Cerrillos", "opcionId": "partido-colorado", "votos": 162, "validos": 4459}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Migues", "opcionId": "partido-nacional", "votos": 2101, "validos": 2805}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Migues", "opcionId": "frente-amplio", "votos": 658, "validos": 2805}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Migues", "opcionId": "partido-colorado", "votos": 46, "validos": 2805}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Montes", "opcionId": "partido-nacional", "votos": 666, "validos": 1168}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Montes", "opcionId": "frente-amplio", "votos": 482, "validos": 1168}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Montes", "opcionId": "cabildo-abierto", "votos": 20, "validos": 1168}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Pando", "opcionId": "frente-amplio", "votos": 7990, "validos": 16023}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Pando", "opcionId": "partido-nacional", "votos": 6670, "validos": 16023}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Pando", "opcionId": "partido-colorado", "votos": 952, "validos": 16023}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Pando", "opcionId": "cabildo-abierto", "votos": 358, "validos": 16023}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Pando", "opcionId": "asamblea-popular", "votos": 53, "validos": 16023}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Parque del Plata", "opcionId": "frente-amplio", "votos": 2337, "validos": 4347}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Parque del Plata", "opcionId": "partido-nacional", "votos": 1733, "validos": 4347}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Parque del Plata", "opcionId": "cabildo-abierto", "votos": 144, "validos": 4347}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Parque del Plata", "opcionId": "partido-colorado", "votos": 71, "validos": 4347}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Parque del Plata", "opcionId": "asamblea-popular", "votos": 62, "validos": 4347}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "frente-amplio", "votos": 3760, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "partido-nacional", "votos": 1564, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "cabildo-abierto", "votos": 193, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "partido-verde-animalista", "votos": 99, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "asamblea-popular", "votos": 79, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Paso Carrasco", "opcionId": "partido-colorado", "votos": 74, "validos": 5769}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Progreso", "opcionId": "frente-amplio", "votos": 5402, "validos": 7801}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Progreso", "opcionId": "partido-nacional", "votos": 1721, "validos": 7801}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Progreso", "opcionId": "partido-colorado", "votos": 456, "validos": 7801}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Progreso", "opcionId": "cabildo-abierto", "votos": 222, "validos": 7801}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Salinas", "opcionId": "frente-amplio", "votos": 4837, "validos": 7797}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Salinas", "opcionId": "partido-nacional", "votos": 2363, "validos": 7797}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Salinas", "opcionId": "cabildo-abierto", "votos": 282, "validos": 7797}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Salinas", "opcionId": "partido-colorado", "votos": 258, "validos": 7797}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Salinas", "opcionId": "asamblea-popular", "votos": 57, "validos": 7797}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Antonio", "opcionId": "partido-nacional", "votos": 1356, "validos": 1986}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Antonio", "opcionId": "frente-amplio", "votos": 496, "validos": 1986}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Antonio", "opcionId": "partido-colorado", "votos": 134, "validos": 1986}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Bautista", "opcionId": "partido-nacional", "votos": 1420, "validos": 2471}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Bautista", "opcionId": "partido-colorado", "votos": 578, "validos": 2471}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Bautista", "opcionId": "frente-amplio", "votos": 473, "validos": 2471}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Jacinto", "opcionId": "partido-nacional", "votos": 3310, "validos": 4574}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Jacinto", "opcionId": "frente-amplio", "votos": 874, "validos": 4574}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Jacinto", "opcionId": "partido-colorado", "votos": 390, "validos": 4574}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Ramón", "opcionId": "partido-nacional", "votos": 2917, "validos": 4968}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Ramón", "opcionId": "frente-amplio", "votos": 1138, "validos": 4968}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Ramón", "opcionId": "partido-colorado", "votos": 787, "validos": 4968}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "San Ramón", "opcionId": "cabildo-abierto", "votos": 126, "validos": 4968}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Lucía", "opcionId": "frente-amplio", "votos": 5216, "validos": 8893}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Lucía", "opcionId": "partido-nacional", "votos": 3282, "validos": 8893}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Lucía", "opcionId": "partido-colorado", "votos": 325, "validos": 8893}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Lucía", "opcionId": "cabildo-abierto", "votos": 70, "validos": 8893}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Rosa", "opcionId": "frente-amplio", "votos": 1477, "validos": 3235}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Rosa", "opcionId": "partido-colorado", "votos": 893, "validos": 3235}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Santa Rosa", "opcionId": "partido-nacional", "votos": 865, "validos": 3235}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Sauce", "opcionId": "partido-nacional", "votos": 2969, "validos": 6292}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Sauce", "opcionId": "frente-amplio", "votos": 2287, "validos": 6292}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Sauce", "opcionId": "partido-colorado", "votos": 917, "validos": 6292}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Sauce", "opcionId": "asamblea-popular", "votos": 60, "validos": 6292}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Sauce", "opcionId": "cabildo-abierto", "votos": 59, "validos": 6292}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Soca", "opcionId": "partido-nacional", "votos": 760, "validos": 1739}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Soca", "opcionId": "partido-colorado", "votos": 621, "validos": 1739}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Soca", "opcionId": "frente-amplio", "votos": 320, "validos": 1739}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Soca", "opcionId": "cabildo-abierto", "votos": 38, "validos": 1739}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Suárez", "opcionId": "frente-amplio", "votos": 3418, "validos": 6160}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Suárez", "opcionId": "partido-nacional", "votos": 2212, "validos": 6160}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Suárez", "opcionId": "partido-colorado", "votos": 292, "validos": 6160}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Suárez", "opcionId": "cabildo-abierto", "votos": 214, "validos": 6160}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Suárez", "opcionId": "asamblea-popular", "votos": 24, "validos": 6160}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Tala", "opcionId": "partido-nacional", "votos": 2878, "validos": 5870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Tala", "opcionId": "frente-amplio", "votos": 1648, "validos": 5870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Tala", "opcionId": "partido-colorado", "votos": 1208, "validos": 5870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Tala", "opcionId": "cabildo-abierto", "votos": 136, "validos": 5870}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Toledo", "opcionId": "frente-amplio", "votos": 3860, "validos": 7182}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Toledo", "opcionId": "partido-nacional", "votos": 1739, "validos": 7182}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Toledo", "opcionId": "cabildo-abierto", "votos": 957, "validos": 7182}
+{"eleccion": "municipales-2020", "departamento": "canelones", "geoId": "Toledo", "opcionId": "partido-colorado", "votos": 626, "validos": 7182}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Aiguá", "opcionId": "partido-nacional", "votos": 1240, "validos": 2149}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Aiguá", "opcionId": "partido-colorado", "votos": 675, "validos": 2149}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Aiguá", "opcionId": "cabildo-abierto", "votos": 120, "validos": 2149}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Aiguá", "opcionId": "frente-amplio", "votos": 114, "validos": 2149}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Garzón", "opcionId": "partido-nacional", "votos": 414, "validos": 491}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Garzón", "opcionId": "frente-amplio", "votos": 72, "validos": 491}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Garzón", "opcionId": "cabildo-abierto", "votos": 3, "validos": 491}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Garzón", "opcionId": "partido-colorado", "votos": 2, "validos": 491}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Maldonado", "opcionId": "partido-nacional", "votos": 26879, "validos": 38827}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Maldonado", "opcionId": "frente-amplio", "votos": 9321, "validos": 38827}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Maldonado", "opcionId": "partido-colorado", "votos": 1867, "validos": 38827}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Maldonado", "opcionId": "cabildo-abierto", "votos": 674, "validos": 38827}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Maldonado", "opcionId": "asamblea-popular", "votos": 86, "validos": 38827}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Pan de Azúcar", "opcionId": "partido-nacional", "votos": 3453, "validos": 5517}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Pan de Azúcar", "opcionId": "frente-amplio", "votos": 1690, "validos": 5517}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Pan de Azúcar", "opcionId": "partido-colorado", "votos": 238, "validos": 5517}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Pan de Azúcar", "opcionId": "cabildo-abierto", "votos": 136, "validos": 5517}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Piriápolis", "opcionId": "partido-nacional", "votos": 3750, "validos": 7928}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Piriápolis", "opcionId": "frente-amplio", "votos": 3442, "validos": 7928}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Piriápolis", "opcionId": "partido-colorado", "votos": 659, "validos": 7928}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Piriápolis", "opcionId": "cabildo-abierto", "votos": 59, "validos": 7928}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Piriápolis", "opcionId": "asamblea-popular", "votos": 18, "validos": 7928}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Punta del Este", "opcionId": "partido-nacional", "votos": 3310, "validos": 4362}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Punta del Este", "opcionId": "frente-amplio", "votos": 558, "validos": 4362}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Punta del Este", "opcionId": "partido-colorado", "votos": 364, "validos": 4362}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Punta del Este", "opcionId": "cabildo-abierto", "votos": 130, "validos": 4362}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "San Carlos", "opcionId": "partido-nacional", "votos": 9858, "validos": 17172}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "San Carlos", "opcionId": "frente-amplio", "votos": 5915, "validos": 17172}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "San Carlos", "opcionId": "partido-colorado", "votos": 561, "validos": 17172}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "San Carlos", "opcionId": "asamblea-popular", "votos": 516, "validos": 17172}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "San Carlos", "opcionId": "cabildo-abierto", "votos": 322, "validos": 17172}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Solís Grande", "opcionId": "partido-nacional", "votos": 1544, "validos": 1965}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Solís Grande", "opcionId": "frente-amplio", "votos": 402, "validos": 1965}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Solís Grande", "opcionId": "cabildo-abierto", "votos": 12, "validos": 1965}
+{"eleccion": "municipales-2020", "departamento": "maldonado", "geoId": "Solís Grande", "opcionId": "partido-colorado", "votos": 7, "validos": 1965}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Carmelo", "opcionId": "partido-nacional", "votos": 5907, "validos": 10350}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Carmelo", "opcionId": "frente-amplio", "votos": 4040, "validos": 10350}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Carmelo", "opcionId": "partido-colorado", "votos": 361, "validos": 10350}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Carmelo", "opcionId": "asamblea-popular", "votos": 42, "validos": 10350}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Miguelete", "opcionId": "partido-nacional", "votos": 698, "validos": 971}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Miguelete", "opcionId": "partido-colorado", "votos": 215, "validos": 971}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Miguelete", "opcionId": "frente-amplio", "votos": 58, "validos": 971}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Valdense", "opcionId": "partido-nacional", "votos": 1413, "validos": 2288}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Valdense", "opcionId": "frente-amplio", "votos": 553, "validos": 2288}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Colonia Valdense", "opcionId": "partido-colorado", "votos": 322, "validos": 2288}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Florencio Sánchez", "opcionId": "partido-nacional", "votos": 1190, "validos": 1509}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Florencio Sánchez", "opcionId": "frente-amplio", "votos": 242, "validos": 1509}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Florencio Sánchez", "opcionId": "partido-colorado", "votos": 77, "validos": 1509}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Juan L. Lacaze", "opcionId": "frente-amplio", "votos": 4486, "validos": 7929}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Juan L. Lacaze", "opcionId": "partido-nacional", "votos": 3103, "validos": 7929}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Juan L. Lacaze", "opcionId": "partido-colorado", "votos": 255, "validos": 7929}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Juan L. Lacaze", "opcionId": "asamblea-popular", "votos": 85, "validos": 7929}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "La Paz", "opcionId": "partido-nacional", "votos": 530, "validos": 806}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "La Paz", "opcionId": "partido-colorado", "votos": 142, "validos": 806}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "La Paz", "opcionId": "frente-amplio", "votos": 134, "validos": 806}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Helvecia", "opcionId": "partido-nacional", "votos": 3438, "validos": 6543}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Helvecia", "opcionId": "frente-amplio", "votos": 2293, "validos": 6543}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Helvecia", "opcionId": "partido-colorado", "votos": 812, "validos": 6543}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Palmira", "opcionId": "partido-nacional", "votos": 3628, "validos": 5590}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Palmira", "opcionId": "frente-amplio", "votos": 1617, "validos": 5590}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Palmira", "opcionId": "partido-colorado", "votos": 315, "validos": 5590}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Nueva Palmira", "opcionId": "asamblea-popular", "votos": 30, "validos": 5590}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Ombúes de Lavalle", "opcionId": "partido-nacional", "votos": 2115, "validos": 2935}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Ombúes de Lavalle", "opcionId": "frente-amplio", "votos": 670, "validos": 2935}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Ombúes de Lavalle", "opcionId": "partido-colorado", "votos": 150, "validos": 2935}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Rosario", "opcionId": "partido-nacional", "votos": 4154, "validos": 6511}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Rosario", "opcionId": "frente-amplio", "votos": 2129, "validos": 6511}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Rosario", "opcionId": "partido-colorado", "votos": 228, "validos": 6511}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Tarariras", "opcionId": "partido-nacional", "votos": 3049, "validos": 4593}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Tarariras", "opcionId": "frente-amplio", "votos": 1215, "validos": 4593}
+{"eleccion": "municipales-2020", "departamento": "colonia", "geoId": "Tarariras", "opcionId": "partido-colorado", "votos": 329, "validos": 4593}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Colonia Lavalleja", "opcionId": "partido-nacional", "votos": 699, "validos": 1664}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Colonia Lavalleja", "opcionId": "partido-colorado", "votos": 511, "validos": 1664}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Colonia Lavalleja", "opcionId": "frente-amplio", "votos": 454, "validos": 1664}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Mataojo", "opcionId": "frente-amplio", "votos": 289, "validos": 685}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Mataojo", "opcionId": "partido-nacional", "votos": 208, "validos": 685}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Mataojo", "opcionId": "partido-colorado", "votos": 188, "validos": 685}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Belén", "opcionId": "frente-amplio", "votos": 696, "validos": 1575}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Belén", "opcionId": "partido-colorado", "votos": 601, "validos": 1575}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Belén", "opcionId": "partido-nacional", "votos": 278, "validos": 1575}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Rincón de Valentín", "opcionId": "frente-amplio", "votos": 453, "validos": 911}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Rincón de Valentín", "opcionId": "partido-colorado", "votos": 255, "validos": 911}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo Rincón de Valentín", "opcionId": "partido-nacional", "votos": 203, "validos": 911}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo San Antonio", "opcionId": "partido-colorado", "votos": 701, "validos": 1726}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo San Antonio", "opcionId": "frente-amplio", "votos": 582, "validos": 1726}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Pueblo San Antonio", "opcionId": "partido-nacional", "votos": 443, "validos": 1726}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Villa Constitución", "opcionId": "frente-amplio", "votos": 1177, "validos": 2393}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Villa Constitución", "opcionId": "partido-colorado", "votos": 761, "validos": 2393}
+{"eleccion": "municipales-2020", "departamento": "salto", "geoId": "Villa Constitución", "opcionId": "partido-nacional", "votos": 455, "validos": 2393}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Chapicuy", "opcionId": "partido-nacional", "votos": 522, "validos": 652}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Chapicuy", "opcionId": "partido-colorado", "votos": 71, "validos": 652}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Chapicuy", "opcionId": "frente-amplio", "votos": 59, "validos": 652}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Guichón", "opcionId": "partido-nacional", "votos": 2325, "validos": 4492}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Guichón", "opcionId": "partido-colorado", "votos": 1528, "validos": 4492}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Guichón", "opcionId": "frente-amplio", "votos": 527, "validos": 4492}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Guichón", "opcionId": "partido-ecologista-radical-intransigente", "votos": 112, "validos": 4492}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Lorenzo Geyres", "opcionId": "partido-nacional", "votos": 628, "validos": 879}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Lorenzo Geyres", "opcionId": "frente-amplio", "votos": 251, "validos": 879}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Piedras Coloradas", "opcionId": "partido-nacional", "votos": 887, "validos": 1117}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Piedras Coloradas", "opcionId": "frente-amplio", "votos": 202, "validos": 1117}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Piedras Coloradas", "opcionId": "partido-colorado", "votos": 28, "validos": 1117}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Porvenir", "opcionId": "partido-nacional", "votos": 1514, "validos": 2105}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Porvenir", "opcionId": "frente-amplio", "votos": 430, "validos": 2105}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Porvenir", "opcionId": "partido-colorado", "votos": 161, "validos": 2105}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Quebracho", "opcionId": "partido-nacional", "votos": 1080, "validos": 2206}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Quebracho", "opcionId": "partido-colorado", "votos": 580, "validos": 2206}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Quebracho", "opcionId": "frente-amplio", "votos": 546, "validos": 2206}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Tambores", "opcionId": "partido-nacional", "votos": 494, "validos": 637}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Tambores", "opcionId": "frente-amplio", "votos": 95, "validos": 637}
+{"eleccion": "municipales-2020", "departamento": "paysandu", "geoId": "Tambores", "opcionId": "partido-colorado", "votos": 48, "validos": 637}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Minas de Corrales", "opcionId": "partido-colorado", "votos": 1423, "validos": 2517}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Minas de Corrales", "opcionId": "partido-nacional", "votos": 934, "validos": 2517}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Minas de Corrales", "opcionId": "frente-amplio", "votos": 108, "validos": 2517}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Minas de Corrales", "opcionId": "cabildo-abierto", "votos": 52, "validos": 2517}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Tranqueras", "opcionId": "partido-colorado", "votos": 3711, "validos": 4980}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Tranqueras", "opcionId": "partido-nacional", "votos": 1060, "validos": 4980}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Tranqueras", "opcionId": "frente-amplio", "votos": 125, "validos": 4980}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Tranqueras", "opcionId": "cabildo-abierto", "votos": 84, "validos": 4980}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Vichadero", "opcionId": "partido-nacional", "votos": 1889, "validos": 2663}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Vichadero", "opcionId": "partido-colorado", "votos": 681, "validos": 2663}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Vichadero", "opcionId": "frente-amplio", "votos": 55, "validos": 2663}
+{"eleccion": "municipales-2020", "departamento": "rivera", "geoId": "Vichadero", "opcionId": "cabildo-abierto", "votos": 38, "validos": 2663}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Aceguá", "opcionId": "partido-nacional", "votos": 1290, "validos": 1339}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Aceguá", "opcionId": "frente-amplio", "votos": 49, "validos": 1339}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Arbolito", "opcionId": "partido-nacional", "votos": 261, "validos": 267}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Arbolito", "opcionId": "frente-amplio", "votos": 6, "validos": 267}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Arévalo", "opcionId": "partido-nacional", "votos": 384, "validos": 384}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Bañado de Medina", "opcionId": "partido-nacional", "votos": 578, "validos": 590}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Bañado de Medina", "opcionId": "frente-amplio", "votos": 12, "validos": 590}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Centurión", "opcionId": "partido-nacional", "votos": 192, "validos": 198}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Centurión", "opcionId": "frente-amplio", "votos": 6, "validos": 198}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Cerro de las Cuentas", "opcionId": "partido-nacional", "votos": 303, "validos": 328}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Cerro de las Cuentas", "opcionId": "frente-amplio", "votos": 25, "validos": 328}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Fraile Muerto", "opcionId": "partido-nacional", "votos": 2147, "validos": 2319}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Fraile Muerto", "opcionId": "frente-amplio", "votos": 172, "validos": 2319}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Isidoro Noblía", "opcionId": "partido-nacional", "votos": 1528, "validos": 1815}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Isidoro Noblía", "opcionId": "frente-amplio", "votos": 235, "validos": 1815}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Isidoro Noblía", "opcionId": "partido-colorado", "votos": 52, "validos": 1815}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Las Cañas", "opcionId": "partido-nacional", "votos": 289, "validos": 318}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Las Cañas", "opcionId": "frente-amplio", "votos": 29, "validos": 318}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Plácido Rosas", "opcionId": "partido-nacional", "votos": 233, "validos": 442}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Plácido Rosas", "opcionId": "frente-amplio", "votos": 209, "validos": 442}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Quebracho", "opcionId": "partido-nacional", "votos": 110, "validos": 116}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Quebracho", "opcionId": "frente-amplio", "votos": 6, "validos": 116}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Ramón Trigo", "opcionId": "partido-nacional", "votos": 193, "validos": 202}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Ramón Trigo", "opcionId": "frente-amplio", "votos": 9, "validos": 202}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Río Branco", "opcionId": "partido-nacional", "votos": 9921, "validos": 10579}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Río Branco", "opcionId": "frente-amplio", "votos": 545, "validos": 10579}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Río Branco", "opcionId": "partido-colorado", "votos": 113, "validos": 10579}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Tres Islas", "opcionId": "partido-nacional", "votos": 243, "validos": 248}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Tres Islas", "opcionId": "frente-amplio", "votos": 5, "validos": 248}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Tupambaé", "opcionId": "partido-nacional", "votos": 593, "validos": 608}
+{"eleccion": "municipales-2020", "departamento": "cerro_largo", "geoId": "Tupambaé", "opcionId": "frente-amplio", "votos": 15, "validos": 608}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Ansina", "opcionId": "partido-nacional", "votos": 1768, "validos": 2120}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Ansina", "opcionId": "partido-colorado", "votos": 186, "validos": 2120}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Ansina", "opcionId": "frente-amplio", "votos": 95, "validos": 2120}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Ansina", "opcionId": "cabildo-abierto", "votos": 71, "validos": 2120}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Paso de los Toros", "opcionId": "partido-nacional", "votos": 4372, "validos": 8565}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Paso de los Toros", "opcionId": "frente-amplio", "votos": 2359, "validos": 8565}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Paso de los Toros", "opcionId": "cabildo-abierto", "votos": 1496, "validos": 8565}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "Paso de los Toros", "opcionId": "partido-colorado", "votos": 338, "validos": 8565}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "San Gregorio de Polanco", "opcionId": "partido-nacional", "votos": 2195, "validos": 2752}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "San Gregorio de Polanco", "opcionId": "frente-amplio", "votos": 311, "validos": 2752}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "San Gregorio de Polanco", "opcionId": "partido-colorado", "votos": 174, "validos": 2752}
+{"eleccion": "municipales-2020", "departamento": "tacuarembo", "geoId": "San Gregorio de Polanco", "opcionId": "cabildo-abierto", "votos": 72, "validos": 2752}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ciudad del Plata", "opcionId": "partido-nacional", "votos": 6226, "validos": 12839}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ciudad del Plata", "opcionId": "frente-amplio", "votos": 6168, "validos": 12839}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ciudad del Plata", "opcionId": "cabildo-abierto", "votos": 220, "validos": 12839}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ciudad del Plata", "opcionId": "partido-colorado", "votos": 152, "validos": 12839}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ciudad del Plata", "opcionId": "asamblea-popular", "votos": 73, "validos": 12839}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ecilda Paullier", "opcionId": "partido-nacional", "votos": 2495, "validos": 3062}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ecilda Paullier", "opcionId": "frente-amplio", "votos": 295, "validos": 3062}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ecilda Paullier", "opcionId": "partido-colorado", "votos": 176, "validos": 3062}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ecilda Paullier", "opcionId": "cabildo-abierto", "votos": 60, "validos": 3062}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Ecilda Paullier", "opcionId": "partido-independiente", "votos": 36, "validos": 3062}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Libertad", "opcionId": "partido-nacional", "votos": 4707, "validos": 7052}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Libertad", "opcionId": "frente-amplio", "votos": 1878, "validos": 7052}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Libertad", "opcionId": "partido-colorado", "votos": 359, "validos": 7052}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Libertad", "opcionId": "cabildo-abierto", "votos": 108, "validos": 7052}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Rodríguez", "opcionId": "partido-nacional", "votos": 2090, "validos": 2754}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Rodríguez", "opcionId": "frente-amplio", "votos": 594, "validos": 2754}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Rodríguez", "opcionId": "partido-colorado", "votos": 51, "validos": 2754}
+{"eleccion": "municipales-2020", "departamento": "san_jose", "geoId": "Rodríguez", "opcionId": "cabildo-abierto", "votos": 19, "validos": 2754}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Cardona", "opcionId": "partido-nacional", "votos": 2489, "validos": 3885}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Cardona", "opcionId": "frente-amplio", "votos": 922, "validos": 3885}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Cardona", "opcionId": "partido-colorado", "votos": 426, "validos": 3885}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Cardona", "opcionId": "cabildo-abierto", "votos": 48, "validos": 3885}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Dolores", "opcionId": "partido-nacional", "votos": 7829, "validos": 11422}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Dolores", "opcionId": "frente-amplio", "votos": 2132, "validos": 11422}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Dolores", "opcionId": "partido-colorado", "votos": 1149, "validos": 11422}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Dolores", "opcionId": "cabildo-abierto", "votos": 312, "validos": 11422}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "José Enrique Rodó", "opcionId": "partido-nacional", "votos": 1262, "validos": 1646}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "José Enrique Rodó", "opcionId": "frente-amplio", "votos": 302, "validos": 1646}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "José Enrique Rodó", "opcionId": "partido-colorado", "votos": 73, "validos": 1646}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "José Enrique Rodó", "opcionId": "cabildo-abierto", "votos": 9, "validos": 1646}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Palmitas", "opcionId": "partido-nacional", "votos": 1024, "validos": 1430}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Palmitas", "opcionId": "partido-colorado", "votos": 294, "validos": 1430}
+{"eleccion": "municipales-2020", "departamento": "soriano", "geoId": "Palmitas", "opcionId": "frente-amplio", "votos": 112, "validos": 1430}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Castillos", "opcionId": "partido-nacional", "votos": 3093, "validos": 5719}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Castillos", "opcionId": "frente-amplio", "votos": 2373, "validos": 5719}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Castillos", "opcionId": "partido-colorado", "votos": 253, "validos": 5719}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Chuy", "opcionId": "partido-nacional", "votos": 4079, "validos": 7160}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Chuy", "opcionId": "frente-amplio", "votos": 2705, "validos": 7160}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Chuy", "opcionId": "partido-colorado", "votos": 324, "validos": 7160}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Chuy", "opcionId": "partido-verde-animalista", "votos": 52, "validos": 7160}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "La Paloma", "opcionId": "frente-amplio", "votos": 1757, "validos": 3311}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "La Paloma", "opcionId": "partido-nacional", "votos": 1398, "validos": 3311}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "La Paloma", "opcionId": "partido-colorado", "votos": 156, "validos": 3311}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Lascano", "opcionId": "partido-nacional", "votos": 2371, "validos": 4749}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Lascano", "opcionId": "frente-amplio", "votos": 1887, "validos": 4749}
+{"eleccion": "municipales-2020", "departamento": "rocha", "geoId": "Lascano", "opcionId": "partido-colorado", "votos": 491, "validos": 4749}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Casupá", "opcionId": "partido-nacional", "votos": 1435, "validos": 1753}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Casupá", "opcionId": "frente-amplio", "votos": 161, "validos": 1753}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Casupá", "opcionId": "partido-colorado", "votos": 157, "validos": 1753}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Fray Marcos", "opcionId": "partido-nacional", "votos": 1576, "validos": 2065}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Fray Marcos", "opcionId": "frente-amplio", "votos": 330, "validos": 2065}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Fray Marcos", "opcionId": "partido-colorado", "votos": 159, "validos": 2065}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Sarandí Grande", "opcionId": "partido-nacional", "votos": 3534, "validos": 4665}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Sarandí Grande", "opcionId": "frente-amplio", "votos": 805, "validos": 4665}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Sarandí Grande", "opcionId": "partido-colorado", "votos": 269, "validos": 4665}
+{"eleccion": "municipales-2020", "departamento": "florida", "geoId": "Sarandí Grande", "opcionId": "cabildo-abierto", "votos": 57, "validos": 4665}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Baltasar Brum", "opcionId": "partido-nacional", "votos": 900, "validos": 1706}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Baltasar Brum", "opcionId": "partido-colorado", "votos": 710, "validos": 1706}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Baltasar Brum", "opcionId": "frente-amplio", "votos": 96, "validos": 1706}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Bella Unión", "opcionId": "partido-nacional", "votos": 5560, "validos": 10182}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Bella Unión", "opcionId": "frente-amplio", "votos": 4149, "validos": 10182}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Bella Unión", "opcionId": "partido-colorado", "votos": 473, "validos": 10182}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Tomás Gomensoro", "opcionId": "partido-nacional", "votos": 1626, "validos": 2036}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Tomás Gomensoro", "opcionId": "frente-amplio", "votos": 383, "validos": 2036}
+{"eleccion": "municipales-2020", "departamento": "artigas", "geoId": "Tomás Gomensoro", "opcionId": "partido-colorado", "votos": 27, "validos": 2036}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Sarandí del Yí", "opcionId": "partido-nacional", "votos": 4047, "validos": 4990}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Sarandí del Yí", "opcionId": "frente-amplio", "votos": 599, "validos": 4990}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Sarandí del Yí", "opcionId": "partido-colorado", "votos": 160, "validos": 4990}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Sarandí del Yí", "opcionId": "cabildo-abierto", "votos": 113, "validos": 4990}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Sarandí del Yí", "opcionId": "asamblea-popular", "votos": 71, "validos": 4990}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Villa del Carmen", "opcionId": "partido-nacional", "votos": 1335, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Villa del Carmen", "opcionId": "partido-colorado", "votos": 228, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Villa del Carmen", "opcionId": "cabildo-abierto", "votos": 200, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Villa del Carmen", "opcionId": "frente-amplio", "votos": 80, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "durazno", "geoId": "Villa del Carmen", "opcionId": "asamblea-popular", "votos": 1, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Cerro Chato", "opcionId": "partido-nacional", "votos": 1082, "validos": 1602}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Cerro Chato", "opcionId": "frente-amplio", "votos": 520, "validos": 1602}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "General Enrique Martinez", "opcionId": "partido-nacional", "votos": 992, "validos": 1066}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "General Enrique Martinez", "opcionId": "frente-amplio", "votos": 74, "validos": 1066}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Rincon", "opcionId": "partido-nacional", "votos": 577, "validos": 626}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Rincon", "opcionId": "frente-amplio", "votos": 49, "validos": 626}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Santa Clara de Olimar", "opcionId": "partido-nacional", "votos": 1658, "validos": 1797}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Santa Clara de Olimar", "opcionId": "frente-amplio", "votos": 119, "validos": 1797}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Santa Clara de Olimar", "opcionId": "partido-colorado", "votos": 20, "validos": 1797}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Vergara", "opcionId": "partido-nacional", "votos": 2637, "validos": 2895}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Vergara", "opcionId": "frente-amplio", "votos": 258, "validos": 2895}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Villa Sara", "opcionId": "partido-nacional", "votos": 689, "validos": 830}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Villa Sara", "opcionId": "frente-amplio", "votos": 125, "validos": 830}
+{"eleccion": "municipales-2020", "departamento": "treinta_y_tres", "geoId": "Villa Sara", "opcionId": "partido-colorado", "votos": 16, "validos": 830}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Batlle y Ordóñez", "opcionId": "partido-nacional", "votos": 1530, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Batlle y Ordóñez", "opcionId": "frente-amplio", "votos": 173, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Batlle y Ordóñez", "opcionId": "partido-colorado", "votos": 117, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Batlle y Ordóñez", "opcionId": "cabildo-abierto", "votos": 24, "validos": 1844}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Pedro Varela", "opcionId": "partido-nacional", "votos": 2571, "validos": 3389}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Pedro Varela", "opcionId": "frente-amplio", "votos": 367, "validos": 3389}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Pedro Varela", "opcionId": "partido-colorado", "votos": 269, "validos": 3389}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "José Pedro Varela", "opcionId": "cabildo-abierto", "votos": 182, "validos": 3389}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Mariscala", "opcionId": "partido-nacional", "votos": 956, "validos": 1315}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Mariscala", "opcionId": "partido-colorado", "votos": 197, "validos": 1315}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Mariscala", "opcionId": "cabildo-abierto", "votos": 99, "validos": 1315}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Mariscala", "opcionId": "frente-amplio", "votos": 63, "validos": 1315}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Solís de Mataojo", "opcionId": "partido-nacional", "votos": 1568, "validos": 2133}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Solís de Mataojo", "opcionId": "frente-amplio", "votos": 401, "validos": 2133}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Solís de Mataojo", "opcionId": "cabildo-abierto", "votos": 95, "validos": 2133}
+{"eleccion": "municipales-2020", "departamento": "lavalleja", "geoId": "Solís de Mataojo", "opcionId": "partido-colorado", "votos": 69, "validos": 2133}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Nuevo Berlín", "opcionId": "partido-nacional", "votos": 992, "validos": 1698}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Nuevo Berlín", "opcionId": "frente-amplio", "votos": 553, "validos": 1698}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Nuevo Berlín", "opcionId": "cabildo-abierto", "votos": 82, "validos": 1698}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Nuevo Berlín", "opcionId": "partido-colorado", "votos": 71, "validos": 1698}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "San Javier", "opcionId": "partido-nacional", "votos": 946, "validos": 1522}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "San Javier", "opcionId": "frente-amplio", "votos": 451, "validos": 1522}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "San Javier", "opcionId": "partido-colorado", "votos": 125, "validos": 1522}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Young", "opcionId": "partido-nacional", "votos": 4679, "validos": 9887}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Young", "opcionId": "frente-amplio", "votos": 4062, "validos": 9887}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Young", "opcionId": "partido-colorado", "votos": 1035, "validos": 9887}
+{"eleccion": "municipales-2020", "departamento": "rio_negro", "geoId": "Young", "opcionId": "cabildo-abierto", "votos": 111, "validos": 9887}
+{"eleccion": "municipales-2020", "departamento": "flores", "geoId": "Ismael Cortinas", "opcionId": "partido-nacional", "votos": 822, "validos": 881}
+{"eleccion": "municipales-2020", "departamento": "flores", "geoId": "Ismael Cortinas", "opcionId": "partido-colorado", "votos": 37, "validos": 881}
+{"eleccion": "municipales-2020", "departamento": "flores", "geoId": "Ismael Cortinas", "opcionId": "frente-amplio", "votos": 22, "validos": 881}

--- a/public/api/v1/dumps/municipales-2025.manifest.json
+++ b/public/api/v1/dumps/municipales-2025.manifest.json
@@ -1,0 +1,15 @@
+{
+ "eleccion": "municipales-2025",
+ "registros": 359,
+ "formato": "ndjson",
+ "campos": [
+  "eleccion",
+  "departamento",
+  "geoId",
+  "opcionId",
+  "votos",
+  "validos"
+ ],
+ "fuente": "Corte Electoral del Uruguay",
+ "version": "v1"
+}

--- a/public/api/v1/dumps/municipales-2025.ndjson
+++ b/public/api/v1/dumps/municipales-2025.ndjson
@@ -1,0 +1,359 @@
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "frente-amplio", "votos": 20692, "validos": 39954}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "coalicion-republicana", "votos": 18907, "validos": 39954}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio B", "opcionId": "asamblea-popular", "votos": 355, "validos": 39954}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "coalicion-republicana", "votos": 42416, "validos": 63123}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "frente-amplio", "votos": 20455, "validos": 63123}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio CH", "opcionId": "asamblea-popular", "votos": 252, "validos": 63123}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "frente-amplio", "votos": 19393, "validos": 36477}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "coalicion-republicana", "votos": 16833, "validos": 36477}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio D", "opcionId": "asamblea-popular", "votos": 251, "validos": 36477}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "coalicion-republicana", "votos": 28178, "validos": 49685}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "frente-amplio", "votos": 21280, "validos": 49685}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio E", "opcionId": "asamblea-popular", "votos": 227, "validos": 49685}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "frente-amplio", "votos": 19492, "validos": 38612}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "coalicion-republicana", "votos": 18942, "validos": 38612}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio F", "opcionId": "asamblea-popular", "votos": 178, "validos": 38612}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "frente-amplio", "votos": 22176, "validos": 39351}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "coalicion-republicana", "votos": 16874, "validos": 39351}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio C", "opcionId": "asamblea-popular", "votos": 301, "validos": 39351}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "frente-amplio", "votos": 20775, "validos": 34642}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "coalicion-republicana", "votos": 13642, "validos": 34642}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio G", "opcionId": "asamblea-popular", "votos": 225, "validos": 34642}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "frente-amplio", "votos": 30482, "validos": 42307}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "coalicion-republicana", "votos": 11496, "validos": 42307}
+{"eleccion": "municipales-2025", "departamento": "montevideo", "geoId": "Municipio A", "opcionId": "asamblea-popular", "votos": 329, "validos": 42307}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LAS PIEDRAS", "opcionId": "frente-amplio", "votos": 15554, "validos": 25890}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LAS PIEDRAS", "opcionId": "coalicion-republicana", "votos": 10184, "validos": 25890}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LAS PIEDRAS", "opcionId": "asamblea-popular", "votos": 138, "validos": 25890}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LAS PIEDRAS", "opcionId": "nacional", "votos": 14, "validos": 25890}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "CIUDAD DE LA COSTA", "opcionId": "frente-amplio", "votos": 22146, "validos": 33171}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "CIUDAD DE LA COSTA", "opcionId": "coalicion-republicana", "votos": 10929, "validos": 33171}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "CIUDAD DE LA COSTA", "opcionId": "asamblea-popular", "votos": 96, "validos": 33171}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SALINAS", "opcionId": "frente-amplio", "votos": 5492, "validos": 8627}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SALINAS", "opcionId": "coalicion-republicana", "votos": 3063, "validos": 8627}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SALINAS", "opcionId": "asamblea-popular", "votos": 72, "validos": 8627}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PARQUE DEL PLATA", "opcionId": "frente-amplio", "votos": 2725, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PARQUE DEL PLATA", "opcionId": "coalicion-republicana", "votos": 1979, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PARQUE DEL PLATA", "opcionId": "asamblea-popular", "votos": 28, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "COLONIA NICOLICH", "opcionId": "frente-amplio", "votos": 3271, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "COLONIA NICOLICH", "opcionId": "coalicion-republicana", "votos": 1438, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "COLONIA NICOLICH", "opcionId": "asamblea-popular", "votos": 23, "validos": 4732}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SUÁREZ", "opcionId": "frente-amplio", "votos": 3039, "validos": 5220}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SUÁREZ", "opcionId": "coalicion-republicana", "votos": 2161, "validos": 5220}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SUÁREZ", "opcionId": "asamblea-popular", "votos": 20, "validos": 5220}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "CANELONES", "opcionId": "frente-amplio", "votos": 6749, "validos": 10358}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "CANELONES", "opcionId": "coalicion-republicana", "votos": 3609, "validos": 10358}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SANTA LUCÍA", "opcionId": "frente-amplio", "votos": 5600, "validos": 8647}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SANTA LUCÍA", "opcionId": "coalicion-republicana", "votos": 3047, "validos": 8647}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LOS CERRILLOS", "opcionId": "coalicion-republicana", "votos": 2636, "validos": 4058}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LOS CERRILLOS", "opcionId": "frente-amplio", "votos": 1422, "validos": 4058}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "AGUAS CORRIENTES", "opcionId": "frente-amplio", "votos": 614, "validos": 933}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "AGUAS CORRIENTES", "opcionId": "coalicion-republicana", "votos": 319, "validos": 933}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PROGRESO", "opcionId": "frente-amplio", "votos": 5033, "validos": 7002}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PROGRESO", "opcionId": "coalicion-republicana", "votos": 1969, "validos": 7002}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "18 DE MAYO", "opcionId": "coalicion-republicana", "votos": 3487, "validos": 6833}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "18 DE MAYO", "opcionId": "frente-amplio", "votos": 3346, "validos": 6833}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LA PAZ", "opcionId": "frente-amplio", "votos": 7194, "validos": 9641}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LA PAZ", "opcionId": "coalicion-republicana", "votos": 2447, "validos": 9641}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAUCE", "opcionId": "coalicion-republicana", "votos": 4418, "validos": 6549}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAUCE", "opcionId": "frente-amplio", "votos": 2131, "validos": 6549}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SANTA ROSA", "opcionId": "frente-amplio", "votos": 1792, "validos": 2850}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SANTA ROSA", "opcionId": "coalicion-republicana", "votos": 1058, "validos": 2850}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN JACINTO", "opcionId": "coalicion-republicana", "votos": 3490, "validos": 4764}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN JACINTO", "opcionId": "frente-amplio", "votos": 1274, "validos": 4764}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN RAMÓN", "opcionId": "coalicion-republicana", "votos": 3955, "validos": 4668}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN RAMÓN", "opcionId": "frente-amplio", "votos": 713, "validos": 4668}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "TALA", "opcionId": "coalicion-republicana", "votos": 3877, "validos": 5668}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "TALA", "opcionId": "frente-amplio", "votos": 1791, "validos": 5668}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "MIGUES", "opcionId": "coalicion-republicana", "votos": 2303, "validos": 2746}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "MIGUES", "opcionId": "frente-amplio", "votos": 443, "validos": 2746}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "MONTES", "opcionId": "frente-amplio", "votos": 753, "validos": 1143}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "MONTES", "opcionId": "coalicion-republicana", "votos": 390, "validos": 1143}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SOCA", "opcionId": "coalicion-republicana", "votos": 1113, "validos": 1762}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SOCA", "opcionId": "frente-amplio", "votos": 649, "validos": 1762}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LA FLORESTA", "opcionId": "frente-amplio", "votos": 2981, "validos": 5253}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "LA FLORESTA", "opcionId": "coalicion-republicana", "votos": 2272, "validos": 5253}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PANDO", "opcionId": "frente-amplio", "votos": 8446, "validos": 15091}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PANDO", "opcionId": "coalicion-republicana", "votos": 6645, "validos": 15091}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "EMPALME OLMOS", "opcionId": "coalicion-republicana", "votos": 2193, "validos": 3700}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "EMPALME OLMOS", "opcionId": "frente-amplio", "votos": 1507, "validos": 3700}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "ATLÁNTIDA", "opcionId": "coalicion-republicana", "votos": 3390, "validos": 6282}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "ATLÁNTIDA", "opcionId": "frente-amplio", "votos": 2892, "validos": 6282}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PASO CARRASCO", "opcionId": "frente-amplio", "votos": 3884, "validos": 5121}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "PASO CARRASCO", "opcionId": "coalicion-republicana", "votos": 1237, "validos": 5121}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "BARROS BLANCOS", "opcionId": "frente-amplio", "votos": 6604, "validos": 12357}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "BARROS BLANCOS", "opcionId": "coalicion-republicana", "votos": 5753, "validos": 12357}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "JUANICÓ", "opcionId": "coalicion-republicana", "votos": 1397, "validos": 2067}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "JUANICÓ", "opcionId": "frente-amplio", "votos": 670, "validos": 2067}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN ANTONIO", "opcionId": "coalicion-republicana", "votos": 1322, "validos": 1986}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN ANTONIO", "opcionId": "frente-amplio", "votos": 664, "validos": 1986}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN BAUTISTA", "opcionId": "coalicion-republicana", "votos": 2079, "validos": 2626}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "SAN BAUTISTA", "opcionId": "frente-amplio", "votos": 547, "validos": 2626}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "TOLEDO", "opcionId": "coalicion-republicana", "votos": 3654, "validos": 7218}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "TOLEDO", "opcionId": "frente-amplio", "votos": 3564, "validos": 7218}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "DEL ANDALUZ", "opcionId": "frente-amplio", "votos": 1177, "validos": 1903}
+{"eleccion": "municipales-2025", "departamento": "canelones", "geoId": "DEL ANDALUZ", "opcionId": "coalicion-republicana", "votos": 726, "validos": 1903}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "MALDONADO", "opcionId": "nacional", "votos": 26378, "validos": 35779}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "MALDONADO", "opcionId": "frente-amplio", "votos": 7861, "validos": 35779}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "MALDONADO", "opcionId": "colorado", "votos": 1432, "validos": 35779}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "MALDONADO", "opcionId": "asamblea-popular", "votos": 108, "validos": 35779}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SAN CARLOS", "opcionId": "nacional", "votos": 10531, "validos": 16601}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SAN CARLOS", "opcionId": "frente-amplio", "votos": 5412, "validos": 16601}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SAN CARLOS", "opcionId": "colorado", "votos": 569, "validos": 16601}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SAN CARLOS", "opcionId": "asamblea-popular", "votos": 89, "validos": 16601}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PIRIÁPOLIS", "opcionId": "nacional", "votos": 4651, "validos": 9498}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PIRIÁPOLIS", "opcionId": "frente-amplio", "votos": 4189, "validos": 9498}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PIRIÁPOLIS", "opcionId": "colorado", "votos": 644, "validos": 9498}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PIRIÁPOLIS", "opcionId": "asamblea-popular", "votos": 14, "validos": 9498}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PUNTA DEL ESTE", "opcionId": "nacional", "votos": 4540, "validos": 5352}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PUNTA DEL ESTE", "opcionId": "frente-amplio", "votos": 611, "validos": 5352}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PUNTA DEL ESTE", "opcionId": "colorado", "votos": 201, "validos": 5352}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PAN DE AZÚCAR", "opcionId": "nacional", "votos": 3423, "validos": 5355}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PAN DE AZÚCAR", "opcionId": "frente-amplio", "votos": 1660, "validos": 5355}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "PAN DE AZÚCAR", "opcionId": "colorado", "votos": 272, "validos": 5355}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SOLÍS GRANDE", "opcionId": "nacional", "votos": 1446, "validos": 2085}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SOLÍS GRANDE", "opcionId": "frente-amplio", "votos": 604, "validos": 2085}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "SOLÍS GRANDE", "opcionId": "colorado", "votos": 35, "validos": 2085}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "GARZÓN", "opcionId": "nacional", "votos": 778, "validos": 869}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "GARZÓN", "opcionId": "frente-amplio", "votos": 86, "validos": 869}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "GARZÓN", "opcionId": "colorado", "votos": 5, "validos": 869}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "AIGUÁ", "opcionId": "nacional", "votos": 1750, "validos": 2139}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "AIGUÁ", "opcionId": "frente-amplio", "votos": 227, "validos": 2139}
+{"eleccion": "municipales-2025", "departamento": "maldonado", "geoId": "AIGUÁ", "opcionId": "colorado", "votos": 162, "validos": 2139}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "COLONIA MIGUELETE", "opcionId": "nacional", "votos": 779, "validos": 935}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "COLONIA MIGUELETE", "opcionId": "colorado", "votos": 91, "validos": 935}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "COLONIA MIGUELETE", "opcionId": "frente-amplio", "votos": 65, "validos": 935}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "TARARIRAS", "opcionId": "nacional", "votos": 3736, "validos": 4676}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "TARARIRAS", "opcionId": "frente-amplio", "votos": 857, "validos": 4676}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "TARARIRAS", "opcionId": "colorado", "votos": 83, "validos": 4676}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "ROSARIO", "opcionId": "nacional", "votos": 3545, "validos": 6186}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "ROSARIO", "opcionId": "frente-amplio", "votos": 2536, "validos": 6186}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "ROSARIO", "opcionId": "colorado", "votos": 105, "validos": 6186}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "LA PAZ", "opcionId": "nacional", "votos": 536, "validos": 738}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "LA PAZ", "opcionId": "colorado", "votos": 202, "validos": 738}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CUFRÉ", "opcionId": "nacional", "votos": 527, "validos": 587}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CUFRÉ", "opcionId": "frente-amplio", "votos": 31, "validos": 587}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CUFRÉ", "opcionId": "colorado", "votos": 29, "validos": 587}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA HELVECIA", "opcionId": "nacional", "votos": 4249, "validos": 6640}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA HELVECIA", "opcionId": "frente-amplio", "votos": 2114, "validos": 6640}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA HELVECIA", "opcionId": "colorado", "votos": 277, "validos": 6640}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "FLORENCIO SÁNCHEZ", "opcionId": "nacional", "votos": 1057, "validos": 1527}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "FLORENCIO SÁNCHEZ", "opcionId": "frente-amplio", "votos": 417, "validos": 1527}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "FLORENCIO SÁNCHEZ", "opcionId": "colorado", "votos": 53, "validos": 1527}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "OMBÚES DE LAVALLE", "opcionId": "nacional", "votos": 2288, "validos": 2865}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "OMBÚES DE LAVALLE", "opcionId": "frente-amplio", "votos": 540, "validos": 2865}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "OMBÚES DE LAVALLE", "opcionId": "colorado", "votos": 37, "validos": 2865}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CARMELO", "opcionId": "nacional", "votos": 7068, "validos": 9775}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CARMELO", "opcionId": "frente-amplio", "votos": 2569, "validos": 9775}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CARMELO", "opcionId": "colorado", "votos": 138, "validos": 9775}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA PALMIRA", "opcionId": "nacional", "votos": 3085, "validos": 6193}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA PALMIRA", "opcionId": "frente-amplio", "votos": 3026, "validos": 6193}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "NUEVA PALMIRA", "opcionId": "colorado", "votos": 82, "validos": 6193}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "JUAN L. LACAZE", "opcionId": "frente-amplio", "votos": 4669, "validos": 7445}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "JUAN L. LACAZE", "opcionId": "nacional", "votos": 2628, "validos": 7445}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "JUAN L. LACAZE", "opcionId": "colorado", "votos": 148, "validos": 7445}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "COLONIA VALDENSE", "opcionId": "nacional", "votos": 1976, "validos": 2559}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "COLONIA VALDENSE", "opcionId": "frente-amplio", "votos": 583, "validos": 2559}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CONCHILLAS", "opcionId": "nacional", "votos": 895, "validos": 1127}
+{"eleccion": "municipales-2025", "departamento": "colonia", "geoId": "CONCHILLAS", "opcionId": "frente-amplio", "votos": 232, "validos": 1127}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO SAN ANTONIO", "opcionId": "coalicion-republicana", "votos": 1082, "validos": 1794}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO SAN ANTONIO", "opcionId": "frente-amplio", "votos": 712, "validos": 1794}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "VILLA CONSTITUCIÓN", "opcionId": "frente-amplio", "votos": 1385, "validos": 2491}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "VILLA CONSTITUCIÓN", "opcionId": "coalicion-republicana", "votos": 1106, "validos": 2491}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO BELÉN", "opcionId": "frente-amplio", "votos": 847, "validos": 1542}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO BELÉN", "opcionId": "coalicion-republicana", "votos": 695, "validos": 1542}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "COLONIA LAVALLEJA", "opcionId": "coalicion-republicana", "votos": 1021, "validos": 1676}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "COLONIA LAVALLEJA", "opcionId": "frente-amplio", "votos": 655, "validos": 1676}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO RINCÓN DE VALENTÍN", "opcionId": "frente-amplio", "votos": 554, "validos": 989}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "PUEBLO RINCÓN DE VALENTÍN", "opcionId": "coalicion-republicana", "votos": 435, "validos": 989}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "MATAOJO", "opcionId": "frente-amplio", "votos": 397, "validos": 783}
+{"eleccion": "municipales-2025", "departamento": "salto", "geoId": "MATAOJO", "opcionId": "coalicion-republicana", "votos": 386, "validos": 783}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PORVENIR", "opcionId": "nacional", "votos": 1549, "validos": 2025}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PORVENIR", "opcionId": "frente-amplio", "votos": 450, "validos": 2025}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PORVENIR", "opcionId": "colorado", "votos": 26, "validos": 2025}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "GUICHÓN", "opcionId": "nacional", "votos": 2331, "validos": 4363}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "GUICHÓN", "opcionId": "colorado", "votos": 1305, "validos": 4363}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "GUICHÓN", "opcionId": "frente-amplio", "votos": 727, "validos": 4363}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "TAMBORES", "opcionId": "nacional", "votos": 504, "validos": 628}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "TAMBORES", "opcionId": "frente-amplio", "votos": 93, "validos": 628}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "TAMBORES", "opcionId": "colorado", "votos": 31, "validos": 628}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "QUEBRACHO", "opcionId": "nacional", "votos": 1372, "validos": 2129}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "QUEBRACHO", "opcionId": "frente-amplio", "votos": 502, "validos": 2129}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "QUEBRACHO", "opcionId": "colorado", "votos": 255, "validos": 2129}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "EL EUCALIPTO", "opcionId": "nacional", "votos": 339, "validos": 440}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "EL EUCALIPTO", "opcionId": "colorado", "votos": 56, "validos": 440}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "EL EUCALIPTO", "opcionId": "frente-amplio", "votos": 45, "validos": 440}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "LORENZO GEYRES", "opcionId": "nacional", "votos": 590, "validos": 903}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "LORENZO GEYRES", "opcionId": "frente-amplio", "votos": 309, "validos": 903}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "LORENZO GEYRES", "opcionId": "colorado", "votos": 4, "validos": 903}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CERRO CHATO", "opcionId": "nacional", "votos": 735, "validos": 802}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CERRO CHATO", "opcionId": "frente-amplio", "votos": 66, "validos": 802}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CERRO CHATO", "opcionId": "colorado", "votos": 1, "validos": 802}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CHAPICUY", "opcionId": "nacional", "votos": 340, "validos": 681}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CHAPICUY", "opcionId": "colorado", "votos": 277, "validos": 681}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "CHAPICUY", "opcionId": "frente-amplio", "votos": 64, "validos": 681}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PIEDRAS COLORADAS", "opcionId": "nacional", "votos": 904, "validos": 1055}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PIEDRAS COLORADAS", "opcionId": "frente-amplio", "votos": 150, "validos": 1055}
+{"eleccion": "municipales-2025", "departamento": "paysandu", "geoId": "PIEDRAS COLORADAS", "opcionId": "colorado", "votos": 1, "validos": 1055}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "TRANQUERAS", "opcionId": "colorado", "votos": 4144, "validos": 5089}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "TRANQUERAS", "opcionId": "nacional", "votos": 737, "validos": 5089}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "TRANQUERAS", "opcionId": "frente-amplio", "votos": 208, "validos": 5089}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "MINAS DE CORRALES", "opcionId": "colorado", "votos": 2159, "validos": 2602}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "MINAS DE CORRALES", "opcionId": "nacional", "votos": 285, "validos": 2602}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "MINAS DE CORRALES", "opcionId": "frente-amplio", "votos": 158, "validos": 2602}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "VICHADERO", "opcionId": "nacional", "votos": 1462, "validos": 2811}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "VICHADERO", "opcionId": "colorado", "votos": 1173, "validos": 2811}
+{"eleccion": "municipales-2025", "departamento": "rivera", "geoId": "VICHADERO", "opcionId": "frente-amplio", "votos": 176, "validos": 2811}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "RÍO BRANCO", "opcionId": "nacional", "votos": 9648, "validos": 10297}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "RÍO BRANCO", "opcionId": "frente-amplio", "votos": 559, "validos": 10297}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "RÍO BRANCO", "opcionId": "colorado", "votos": 90, "validos": 10297}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "FRAILE MUERTO", "opcionId": "nacional", "votos": 2062, "validos": 2273}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "FRAILE MUERTO", "opcionId": "frente-amplio", "votos": 202, "validos": 2273}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "FRAILE MUERTO", "opcionId": "colorado", "votos": 9, "validos": 2273}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "TUPAMBAÉ", "opcionId": "nacional", "votos": 663, "validos": 789}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "TUPAMBAÉ", "opcionId": "frente-amplio", "votos": 121, "validos": 789}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "TUPAMBAÉ", "opcionId": "colorado", "votos": 5, "validos": 789}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "BAÑADO DE MEDINA", "opcionId": "nacional", "votos": 786, "validos": 822}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "BAÑADO DE MEDINA", "opcionId": "frente-amplio", "votos": 36, "validos": 822}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "PLÁCIDO ROSAS", "opcionId": "nacional", "votos": 420, "validos": 456}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "PLÁCIDO ROSAS", "opcionId": "frente-amplio", "votos": 36, "validos": 456}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "CERRO DE LAS CUENTAS", "opcionId": "nacional", "votos": 386, "validos": 412}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "CERRO DE LAS CUENTAS", "opcionId": "frente-amplio", "votos": 26, "validos": 412}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "LAS CAÑAS", "opcionId": "nacional", "votos": 296, "validos": 355}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "LAS CAÑAS", "opcionId": "frente-amplio", "votos": 59, "validos": 355}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "LAGUNA MERÍN", "opcionId": "nacional", "votos": 569, "validos": 706}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "LAGUNA MERÍN", "opcionId": "frente-amplio", "votos": 137, "validos": 706}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "CENTURIÓN", "opcionId": "nacional", "votos": 241, "validos": 244}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "CENTURIÓN", "opcionId": "frente-amplio", "votos": 3, "validos": 244}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ISIDORO NOBLÍA", "opcionId": "nacional", "votos": 1923, "validos": 2070}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ISIDORO NOBLÍA", "opcionId": "frente-amplio", "votos": 147, "validos": 2070}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ACEGUÁ", "opcionId": "nacional", "votos": 1240, "validos": 1278}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ACEGUÁ", "opcionId": "frente-amplio", "votos": 38, "validos": 1278}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "TRES ISLAS", "opcionId": "nacional", "votos": 223, "validos": 228}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "TRES ISLAS", "opcionId": "frente-amplio", "votos": 5, "validos": 228}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "RAMÓN TRIGO", "opcionId": "nacional", "votos": 188, "validos": 214}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "RAMÓN TRIGO", "opcionId": "frente-amplio", "votos": 26, "validos": 214}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ARBOLITO", "opcionId": "nacional", "votos": 275, "validos": 275}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "QUEBRACHO", "opcionId": "nacional", "votos": 164, "validos": 164}
+{"eleccion": "municipales-2025", "departamento": "cerro_largo", "geoId": "ARÉVALO", "opcionId": "nacional", "votos": 557, "validos": 557}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "ANSINA", "opcionId": "nacional", "votos": 1900, "validos": 2223}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "ANSINA", "opcionId": "frente-amplio", "votos": 187, "validos": 2223}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "ANSINA", "opcionId": "colorado", "votos": 136, "validos": 2223}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "SAN GREGORIO DE POLANCO", "opcionId": "nacional", "votos": 1876, "validos": 2707}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "SAN GREGORIO DE POLANCO", "opcionId": "frente-amplio", "votos": 657, "validos": 2707}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "SAN GREGORIO DE POLANCO", "opcionId": "colorado", "votos": 174, "validos": 2707}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "PASO DE LOS TOROS", "opcionId": "nacional", "votos": 6604, "validos": 8738}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "PASO DE LOS TOROS", "opcionId": "frente-amplio", "votos": 1853, "validos": 8738}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "PASO DE LOS TOROS", "opcionId": "colorado", "votos": 281, "validos": 8738}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "VILLA CARAGUATÁ", "opcionId": "nacional", "votos": 2396, "validos": 2567}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "VILLA CARAGUATÁ", "opcionId": "frente-amplio", "votos": 88, "validos": 2567}
+{"eleccion": "municipales-2025", "departamento": "tacuarembo", "geoId": "VILLA CARAGUATÁ", "opcionId": "colorado", "votos": 83, "validos": 2567}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "CIUDAD DEL PLATA", "opcionId": "frente-amplio", "votos": 6742, "validos": 12431}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "CIUDAD DEL PLATA", "opcionId": "nacional", "votos": 5574, "validos": 12431}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "CIUDAD DEL PLATA", "opcionId": "colorado", "votos": 84, "validos": 12431}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "CIUDAD DEL PLATA", "opcionId": "asamblea-popular", "votos": 31, "validos": 12431}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "RODRÍGUEZ", "opcionId": "nacional", "votos": 2036, "validos": 2759}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "RODRÍGUEZ", "opcionId": "frente-amplio", "votos": 667, "validos": 2759}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "RODRÍGUEZ", "opcionId": "colorado", "votos": 56, "validos": 2759}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "LIBERTAD", "opcionId": "nacional", "votos": 4416, "validos": 6792}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "LIBERTAD", "opcionId": "frente-amplio", "votos": 2157, "validos": 6792}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "LIBERTAD", "opcionId": "colorado", "votos": 219, "validos": 6792}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "ECILDA PAULLIER", "opcionId": "nacional", "votos": 2492, "validos": 3084}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "ECILDA PAULLIER", "opcionId": "frente-amplio", "votos": 491, "validos": 3084}
+{"eleccion": "municipales-2025", "departamento": "san_jose", "geoId": "ECILDA PAULLIER", "opcionId": "colorado", "votos": 101, "validos": 3084}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "VILLA DE SANTO DOMINGO DE SORIANO", "opcionId": "nacional", "votos": 563, "validos": 885}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "VILLA DE SANTO DOMINGO DE SORIANO", "opcionId": "colorado", "votos": 161, "validos": 885}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "VILLA DE SANTO DOMINGO DE SORIANO", "opcionId": "frente-amplio", "votos": 161, "validos": 885}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "DOLORES", "opcionId": "nacional", "votos": 7759, "validos": 10841}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "DOLORES", "opcionId": "frente-amplio", "votos": 2052, "validos": 10841}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "DOLORES", "opcionId": "colorado", "votos": 1030, "validos": 10841}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "JOSÉ ENRIQUE RODÓ", "opcionId": "nacional", "votos": 1216, "validos": 1596}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "JOSÉ ENRIQUE RODÓ", "opcionId": "frente-amplio", "votos": 323, "validos": 1596}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "JOSÉ ENRIQUE RODÓ", "opcionId": "colorado", "votos": 57, "validos": 1596}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "CARDONA", "opcionId": "nacional", "votos": 2438, "validos": 3821}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "CARDONA", "opcionId": "frente-amplio", "votos": 1035, "validos": 3821}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "CARDONA", "opcionId": "colorado", "votos": 348, "validos": 3821}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "PALMITAS", "opcionId": "nacional", "votos": 865, "validos": 1420}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "PALMITAS", "opcionId": "colorado", "votos": 436, "validos": 1420}
+{"eleccion": "municipales-2025", "departamento": "soriano", "geoId": "PALMITAS", "opcionId": "frente-amplio", "votos": 119, "validos": 1420}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CASTILLOS", "opcionId": "nacional", "votos": 3551, "validos": 5503}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CASTILLOS", "opcionId": "frente-amplio", "votos": 1874, "validos": 5503}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CASTILLOS", "opcionId": "colorado", "votos": 78, "validos": 5503}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LA PALOMA", "opcionId": "frente-amplio", "votos": 2269, "validos": 4321}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LA PALOMA", "opcionId": "nacional", "votos": 2024, "validos": 4321}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LA PALOMA", "opcionId": "colorado", "votos": 28, "validos": 4321}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LASCANO", "opcionId": "nacional", "votos": 3146, "validos": 4924}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LASCANO", "opcionId": "frente-amplio", "votos": 1750, "validos": 4924}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "LASCANO", "opcionId": "colorado", "votos": 28, "validos": 4924}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CHUY", "opcionId": "nacional", "votos": 4924, "validos": 8184}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CHUY", "opcionId": "frente-amplio", "votos": 3220, "validos": 8184}
+{"eleccion": "municipales-2025", "departamento": "rocha", "geoId": "CHUY", "opcionId": "colorado", "votos": 40, "validos": 8184}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "SARANDÍ GRANDE", "opcionId": "nacional", "votos": 3301, "validos": 4532}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "SARANDÍ GRANDE", "opcionId": "frente-amplio", "votos": 939, "validos": 4532}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "SARANDÍ GRANDE", "opcionId": "colorado", "votos": 292, "validos": 4532}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "CASUPÁ", "opcionId": "nacional", "votos": 1477, "validos": 1911}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "CASUPÁ", "opcionId": "frente-amplio", "votos": 326, "validos": 1911}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "CASUPÁ", "opcionId": "colorado", "votos": 108, "validos": 1911}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "FRAY MARCOS", "opcionId": "nacional", "votos": 1480, "validos": 2087}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "FRAY MARCOS", "opcionId": "frente-amplio", "votos": 347, "validos": 2087}
+{"eleccion": "municipales-2025", "departamento": "florida", "geoId": "FRAY MARCOS", "opcionId": "colorado", "votos": 260, "validos": 2087}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "TOMÁS GOMENSORO", "opcionId": "nacional", "votos": 1179, "validos": 1978}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "TOMÁS GOMENSORO", "opcionId": "frente-amplio", "votos": 738, "validos": 1978}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "TOMÁS GOMENSORO", "opcionId": "colorado", "votos": 33, "validos": 1978}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "TOMÁS GOMENSORO", "opcionId": "cabildo-abierto", "votos": 28, "validos": 1978}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BELLA UNIÓN", "opcionId": "nacional", "votos": 5468, "validos": 10721}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BELLA UNIÓN", "opcionId": "frente-amplio", "votos": 4695, "validos": 10721}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BELLA UNIÓN", "opcionId": "colorado", "votos": 463, "validos": 10721}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BELLA UNIÓN", "opcionId": "cabildo-abierto", "votos": 95, "validos": 10721}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BALTASAR BRUM", "opcionId": "nacional", "votos": 971, "validos": 1790}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BALTASAR BRUM", "opcionId": "colorado", "votos": 467, "validos": 1790}
+{"eleccion": "municipales-2025", "departamento": "artigas", "geoId": "BALTASAR BRUM", "opcionId": "frente-amplio", "votos": 352, "validos": 1790}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "SARANDÍ DEL YÍ", "opcionId": "nacional", "votos": 3714, "validos": 4936}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "SARANDÍ DEL YÍ", "opcionId": "frente-amplio", "votos": 1005, "validos": 4936}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "SARANDÍ DEL YÍ", "opcionId": "colorado", "votos": 167, "validos": 4936}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "SARANDÍ DEL YÍ", "opcionId": "asamblea-popular", "votos": 50, "validos": 4936}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "VILLA DEL CARMEN", "opcionId": "nacional", "votos": 1691, "validos": 1943}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "VILLA DEL CARMEN", "opcionId": "frente-amplio", "votos": 186, "validos": 1943}
+{"eleccion": "municipales-2025", "departamento": "durazno", "geoId": "VILLA DEL CARMEN", "opcionId": "colorado", "votos": 66, "validos": 1943}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "VERGARA", "opcionId": "nacional", "votos": 2660, "validos": 2874}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "VERGARA", "opcionId": "frente-amplio", "votos": 214, "validos": 2874}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "GENERAL ENRIQUE MARTÍNEZ", "opcionId": "nacional", "votos": 923, "validos": 1106}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "GENERAL ENRIQUE MARTÍNEZ", "opcionId": "frente-amplio", "votos": 183, "validos": 1106}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "RINCÓN", "opcionId": "nacional", "votos": 524, "validos": 604}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "RINCÓN", "opcionId": "frente-amplio", "votos": 80, "validos": 604}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "SANTA CLARA DE OLIMAR", "opcionId": "nacional", "votos": 1537, "validos": 1671}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "SANTA CLARA DE OLIMAR", "opcionId": "frente-amplio", "votos": 134, "validos": 1671}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "CERRO CHATO", "opcionId": "nacional", "votos": 1240, "validos": 1859}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "CERRO CHATO", "opcionId": "frente-amplio", "votos": 619, "validos": 1859}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "VILLA SARA", "opcionId": "nacional", "votos": 513, "validos": 624}
+{"eleccion": "municipales-2025", "departamento": "treinta_y_tres", "geoId": "VILLA SARA", "opcionId": "frente-amplio", "votos": 111, "validos": 624}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "SOLÍS DE MATAOJO", "opcionId": "nacional", "votos": 1041, "validos": 2097}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "SOLÍS DE MATAOJO", "opcionId": "frente-amplio", "votos": 833, "validos": 2097}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "SOLÍS DE MATAOJO", "opcionId": "colorado", "votos": 223, "validos": 2097}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "MARISCALA", "opcionId": "nacional", "votos": 744, "validos": 1223}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "MARISCALA", "opcionId": "colorado", "votos": 364, "validos": 1223}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "MARISCALA", "opcionId": "frente-amplio", "votos": 115, "validos": 1223}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "PIRARAJÁ", "opcionId": "nacional", "votos": 430, "validos": 526}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "PIRARAJÁ", "opcionId": "frente-amplio", "votos": 91, "validos": 526}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "PIRARAJÁ", "opcionId": "colorado", "votos": 5, "validos": 526}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ PEDRO VARELA", "opcionId": "nacional", "votos": 1870, "validos": 3288}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ PEDRO VARELA", "opcionId": "frente-amplio", "votos": 1097, "validos": 3288}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ PEDRO VARELA", "opcionId": "colorado", "votos": 321, "validos": 3288}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "ZAPICÁN", "opcionId": "nacional", "votos": 361, "validos": 468}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "ZAPICÁN", "opcionId": "colorado", "votos": 61, "validos": 468}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "ZAPICÁN", "opcionId": "frente-amplio", "votos": 46, "validos": 468}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ BATLLE Y ORDÓÑEZ", "opcionId": "colorado", "votos": 759, "validos": 1663}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ BATLLE Y ORDÓÑEZ", "opcionId": "nacional", "votos": 726, "validos": 1663}
+{"eleccion": "municipales-2025", "departamento": "lavalleja", "geoId": "JOSÉ BATLLE Y ORDÓÑEZ", "opcionId": "frente-amplio", "votos": 178, "validos": 1663}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "NUEVO BERLÍN", "opcionId": "nacional", "votos": 826, "validos": 1508}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "NUEVO BERLÍN", "opcionId": "frente-amplio", "votos": 437, "validos": 1508}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "NUEVO BERLÍN", "opcionId": "colorado", "votos": 245, "validos": 1508}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "SAN JAVIER", "opcionId": "nacional", "votos": 544, "validos": 1494}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "SAN JAVIER", "opcionId": "frente-amplio", "votos": 531, "validos": 1494}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "SAN JAVIER", "opcionId": "colorado", "votos": 419, "validos": 1494}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "YOUNG", "opcionId": "frente-amplio", "votos": 3809, "validos": 9028}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "YOUNG", "opcionId": "nacional", "votos": 3522, "validos": 9028}
+{"eleccion": "municipales-2025", "departamento": "rio_negro", "geoId": "YOUNG", "opcionId": "colorado", "votos": 1697, "validos": 9028}
+{"eleccion": "municipales-2025", "departamento": "flores", "geoId": "ISMAEL CORTINAS", "opcionId": "nacional", "votos": 787, "validos": 824}
+{"eleccion": "municipales-2025", "departamento": "flores", "geoId": "ISMAEL CORTINAS", "opcionId": "frente-amplio", "votos": 24, "validos": 824}
+{"eleccion": "municipales-2025", "departamento": "flores", "geoId": "ISMAEL CORTINAS", "opcionId": "colorado", "votos": 13, "validos": 824}

--- a/public/api/v1/elections.json
+++ b/public/api/v1/elections.json
@@ -176,6 +176,56 @@
    "detalle": "/api/v1/elections/internas-2024.json"
   },
   {
+   "id": "municipales-2020",
+   "departamentos": [
+    "artigas",
+    "canelones",
+    "cerro_largo",
+    "colonia",
+    "durazno",
+    "flores",
+    "florida",
+    "lavalleja",
+    "maldonado",
+    "montevideo",
+    "paysandu",
+    "rio_negro",
+    "rivera",
+    "rocha",
+    "salto",
+    "san_jose",
+    "soriano",
+    "tacuarembo",
+    "treinta_y_tres"
+   ],
+   "detalle": "/api/v1/elections/municipales-2020.json"
+  },
+  {
+   "id": "municipales-2025",
+   "departamentos": [
+    "artigas",
+    "canelones",
+    "cerro_largo",
+    "colonia",
+    "durazno",
+    "flores",
+    "florida",
+    "lavalleja",
+    "maldonado",
+    "montevideo",
+    "paysandu",
+    "rio_negro",
+    "rivera",
+    "rocha",
+    "salto",
+    "san_jose",
+    "soriano",
+    "tacuarembo",
+    "treinta_y_tres"
+   ],
+   "detalle": "/api/v1/elections/municipales-2025.json"
+  },
+  {
    "id": "nacionales-2014",
    "departamentos": [
     "artigas",

--- a/public/api/v1/elections/balotaje-2014.json
+++ b/public/api/v1/elections/balotaje-2014.json
@@ -2,6 +2,19 @@
  "id": "balotaje-2014",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/balotaje-2014/_nacional/opciones.json",
+    "votes": "/api/v1/results/balotaje-2014/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/balotaje-2014/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/balotaje-2019.json
+++ b/public/api/v1/elections/balotaje-2019.json
@@ -2,6 +2,19 @@
  "id": "balotaje-2019",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/balotaje-2019/_nacional/opciones.json",
+    "votes": "/api/v1/results/balotaje-2019/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/balotaje-2019/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/balotaje-2024.json
+++ b/public/api/v1/elections/balotaje-2024.json
@@ -2,6 +2,19 @@
  "id": "balotaje-2024",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/balotaje-2024/_nacional/opciones.json",
+    "votes": "/api/v1/results/balotaje-2024/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/balotaje-2024/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/departamentales-2020.json
+++ b/public/api/v1/elections/departamentales-2020.json
@@ -2,6 +2,19 @@
  "id": "departamentales-2020",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/departamentales-2020/_nacional/opciones.json",
+    "votes": "/api/v1/results/departamentales-2020/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "catalogo": "/api/v1/results/departamentales-2020/artigas/catalogo.json",
@@ -15,6 +28,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -30,6 +45,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -47,6 +64,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -62,6 +81,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -79,6 +100,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -94,6 +117,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -109,6 +134,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -124,6 +151,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -139,6 +168,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -153,6 +184,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -170,6 +203,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -185,6 +220,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -202,6 +239,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -217,6 +256,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -234,6 +275,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -251,6 +294,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -266,6 +311,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -281,6 +328,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -298,6 +347,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/departamentales-2025.json
+++ b/public/api/v1/elections/departamentales-2025.json
@@ -2,6 +2,19 @@
  "id": "departamentales-2025",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/departamentales-2025/_nacional/opciones.json",
+    "votes": "/api/v1/results/departamentales-2025/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "catalogo": "/api/v1/results/departamentales-2025/artigas/catalogo.json",
@@ -16,6 +29,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -32,6 +47,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -50,6 +67,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -66,6 +85,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -84,6 +105,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -100,6 +123,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -116,6 +141,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -132,6 +159,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -148,6 +177,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -163,6 +194,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -181,6 +214,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -197,6 +232,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -215,6 +252,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -231,6 +270,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -249,6 +290,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -267,6 +310,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -283,6 +328,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -299,6 +346,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -317,6 +366,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/internas-2019.json
+++ b/public/api/v1/elections/internas-2019.json
@@ -2,6 +2,19 @@
  "id": "internas-2019",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/internas-2019/_nacional/opciones.json",
+    "votes": "/api/v1/results/internas-2019/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "catalogo": "/api/v1/results/internas-2019/artigas/catalogo.json",
@@ -16,6 +29,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -32,6 +47,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -50,6 +67,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -66,6 +85,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -84,6 +105,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -100,6 +123,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -116,6 +141,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -132,6 +159,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -148,6 +177,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -163,6 +194,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -181,6 +214,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -197,6 +232,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -215,6 +252,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -231,6 +270,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -249,6 +290,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -267,6 +310,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -283,6 +328,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -299,6 +346,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -317,6 +366,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/municipales-2020.json
+++ b/public/api/v1/elections/municipales-2020.json
@@ -1,11 +1,13 @@
 {
- "id": "internas-2024",
+ "id": "municipales-2020",
  "departamentos": [
   {
    "id": "_nacional",
    "results": {
-    "opciones": "/api/v1/results/internas-2024/_nacional/opciones.json",
-    "votes": "/api/v1/results/internas-2024/_nacional/votes.json"
+    "opciones": "/api/v1/results/municipales-2020/_nacional/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/_nacional/votes.json",
+    "alcaldes": "/api/v1/results/municipales-2020/_nacional/alcaldes.json",
+    "concejos": "/api/v1/results/municipales-2020/_nacional/concejos.json"
    },
    "geo": {
     "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
@@ -17,13 +19,9 @@
   {
    "id": "artigas",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/artigas/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/artigas/opciones.json",
-    "votes": "/api/v1/results/internas-2024/artigas/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/artigas/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/artigas/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/artigas/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/artigas/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/artigas/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/artigas/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/artigas/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/artigas/barrio.topo.json",
@@ -38,12 +36,9 @@
   {
    "id": "canelones",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/canelones/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/canelones/opciones.json",
-    "votes": "/api/v1/results/internas-2024/canelones/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/canelones/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/canelones/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/canelones/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/canelones/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/canelones/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/canelones/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
@@ -57,13 +52,9 @@
   {
    "id": "cerro_largo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/cerro_largo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/cerro_largo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/cerro_largo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/cerro_largo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/cerro_largo/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/cerro_largo/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/cerro_largo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/cerro_largo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/cerro_largo/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/cerro_largo/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/cerro_largo/barrio.topo.json",
@@ -78,12 +69,9 @@
   {
    "id": "colonia",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/colonia/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/colonia/opciones.json",
-    "votes": "/api/v1/results/internas-2024/colonia/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/colonia/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/colonia/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/colonia/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/colonia/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/colonia/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/colonia/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
@@ -97,13 +85,9 @@
   {
    "id": "durazno",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/durazno/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/durazno/opciones.json",
-    "votes": "/api/v1/results/internas-2024/durazno/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/durazno/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/durazno/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/durazno/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/durazno/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/durazno/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/durazno/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/durazno/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/durazno/barrio.topo.json",
@@ -118,12 +102,9 @@
   {
    "id": "flores",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/flores/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/flores/opciones.json",
-    "votes": "/api/v1/results/internas-2024/flores/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/flores/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/flores/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/flores/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/flores/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/flores/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/flores/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
@@ -137,12 +118,9 @@
   {
    "id": "florida",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/florida/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/florida/opciones.json",
-    "votes": "/api/v1/results/internas-2024/florida/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/florida/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/florida/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/florida/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/florida/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/florida/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/florida/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
@@ -156,12 +134,9 @@
   {
    "id": "lavalleja",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/lavalleja/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/lavalleja/opciones.json",
-    "votes": "/api/v1/results/internas-2024/lavalleja/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/lavalleja/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/lavalleja/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/lavalleja/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/lavalleja/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/lavalleja/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/lavalleja/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
@@ -175,12 +150,9 @@
   {
    "id": "maldonado",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/maldonado/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/maldonado/opciones.json",
-    "votes": "/api/v1/results/internas-2024/maldonado/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/maldonado/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/maldonado/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/maldonado/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/maldonado/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/maldonado/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/maldonado/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
@@ -194,12 +166,9 @@
   {
    "id": "montevideo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/montevideo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/montevideo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/montevideo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/montevideo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/montevideo/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/montevideo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/montevideo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/montevideo/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/montevideo/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
@@ -212,13 +181,9 @@
   {
    "id": "paysandu",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/paysandu/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/paysandu/opciones.json",
-    "votes": "/api/v1/results/internas-2024/paysandu/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/paysandu/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/paysandu/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/paysandu/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/paysandu/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/paysandu/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/paysandu/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/paysandu/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/paysandu/barrio.topo.json",
@@ -233,12 +198,9 @@
   {
    "id": "rio_negro",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rio_negro/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rio_negro/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rio_negro/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rio_negro/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rio_negro/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/rio_negro/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/rio_negro/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/rio_negro/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/rio_negro/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
@@ -252,13 +214,9 @@
   {
    "id": "rivera",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rivera/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rivera/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rivera/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rivera/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rivera/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/rivera/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/rivera/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/rivera/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/rivera/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/rivera/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/rivera/barrio.topo.json",
@@ -273,12 +231,9 @@
   {
    "id": "rocha",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rocha/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rocha/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rocha/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rocha/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rocha/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/rocha/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/rocha/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/rocha/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/rocha/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
@@ -292,13 +247,9 @@
   {
    "id": "salto",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/salto/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/salto/opciones.json",
-    "votes": "/api/v1/results/internas-2024/salto/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/salto/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/salto/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/salto/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/salto/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/salto/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/salto/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/salto/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/salto/barrio.topo.json",
@@ -313,13 +264,9 @@
   {
    "id": "san_jose",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/san_jose/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/san_jose/opciones.json",
-    "votes": "/api/v1/results/internas-2024/san_jose/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/san_jose/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/san_jose/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/san_jose/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/san_jose/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/san_jose/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/san_jose/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/san_jose/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/san_jose/barrio.topo.json",
@@ -334,12 +281,9 @@
   {
    "id": "soriano",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/soriano/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/soriano/opciones.json",
-    "votes": "/api/v1/results/internas-2024/soriano/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/soriano/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/soriano/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/soriano/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/soriano/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/soriano/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/soriano/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
@@ -353,12 +297,9 @@
   {
    "id": "tacuarembo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/tacuarembo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/tacuarembo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/tacuarembo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/tacuarembo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/tacuarembo/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/tacuarembo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/tacuarembo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/tacuarembo/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/tacuarembo/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
@@ -372,13 +313,9 @@
   {
    "id": "treinta_y_tres",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/treinta_y_tres/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/treinta_y_tres/opciones.json",
-    "votes": "/api/v1/results/internas-2024/treinta_y_tres/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/treinta_y_tres/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/treinta_y_tres/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/treinta_y_tres/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/treinta_y_tres/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2020/treinta_y_tres/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2020/treinta_y_tres/opciones.json",
+    "votes": "/api/v1/results/municipales-2020/treinta_y_tres/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/treinta_y_tres/barrio.topo.json",

--- a/public/api/v1/elections/municipales-2025.json
+++ b/public/api/v1/elections/municipales-2025.json
@@ -1,11 +1,13 @@
 {
- "id": "internas-2024",
+ "id": "municipales-2025",
  "departamentos": [
   {
    "id": "_nacional",
    "results": {
-    "opciones": "/api/v1/results/internas-2024/_nacional/opciones.json",
-    "votes": "/api/v1/results/internas-2024/_nacional/votes.json"
+    "opciones": "/api/v1/results/municipales-2025/_nacional/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/_nacional/votes.json",
+    "alcaldes": "/api/v1/results/municipales-2025/_nacional/alcaldes.json",
+    "concejos": "/api/v1/results/municipales-2025/_nacional/concejos.json"
    },
    "geo": {
     "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
@@ -17,13 +19,9 @@
   {
    "id": "artigas",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/artigas/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/artigas/opciones.json",
-    "votes": "/api/v1/results/internas-2024/artigas/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/artigas/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/artigas/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/artigas/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/artigas/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/artigas/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/artigas/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/artigas/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/artigas/barrio.topo.json",
@@ -38,12 +36,9 @@
   {
    "id": "canelones",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/canelones/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/canelones/opciones.json",
-    "votes": "/api/v1/results/internas-2024/canelones/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/canelones/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/canelones/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/canelones/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/canelones/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/canelones/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/canelones/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
@@ -57,13 +52,9 @@
   {
    "id": "cerro_largo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/cerro_largo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/cerro_largo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/cerro_largo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/cerro_largo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/cerro_largo/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/cerro_largo/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/cerro_largo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/cerro_largo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/cerro_largo/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/cerro_largo/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/cerro_largo/barrio.topo.json",
@@ -78,12 +69,9 @@
   {
    "id": "colonia",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/colonia/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/colonia/opciones.json",
-    "votes": "/api/v1/results/internas-2024/colonia/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/colonia/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/colonia/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/colonia/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/colonia/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/colonia/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/colonia/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
@@ -97,13 +85,9 @@
   {
    "id": "durazno",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/durazno/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/durazno/opciones.json",
-    "votes": "/api/v1/results/internas-2024/durazno/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/durazno/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/durazno/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/durazno/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/durazno/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/durazno/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/durazno/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/durazno/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/durazno/barrio.topo.json",
@@ -118,12 +102,9 @@
   {
    "id": "flores",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/flores/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/flores/opciones.json",
-    "votes": "/api/v1/results/internas-2024/flores/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/flores/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/flores/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/flores/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/flores/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/flores/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/flores/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
@@ -137,12 +118,9 @@
   {
    "id": "florida",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/florida/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/florida/opciones.json",
-    "votes": "/api/v1/results/internas-2024/florida/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/florida/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/florida/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/florida/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/florida/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/florida/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/florida/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
@@ -156,12 +134,9 @@
   {
    "id": "lavalleja",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/lavalleja/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/lavalleja/opciones.json",
-    "votes": "/api/v1/results/internas-2024/lavalleja/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/lavalleja/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/lavalleja/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/lavalleja/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/lavalleja/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/lavalleja/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/lavalleja/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
@@ -175,12 +150,9 @@
   {
    "id": "maldonado",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/maldonado/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/maldonado/opciones.json",
-    "votes": "/api/v1/results/internas-2024/maldonado/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/maldonado/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/maldonado/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/maldonado/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/maldonado/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/maldonado/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/maldonado/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
@@ -194,12 +166,9 @@
   {
    "id": "montevideo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/montevideo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/montevideo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/montevideo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/montevideo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/montevideo/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/montevideo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/montevideo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/montevideo/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/montevideo/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
@@ -212,13 +181,9 @@
   {
    "id": "paysandu",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/paysandu/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/paysandu/opciones.json",
-    "votes": "/api/v1/results/internas-2024/paysandu/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/paysandu/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/paysandu/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/paysandu/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/paysandu/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/paysandu/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/paysandu/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/paysandu/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/paysandu/barrio.topo.json",
@@ -233,12 +198,9 @@
   {
    "id": "rio_negro",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rio_negro/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rio_negro/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rio_negro/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rio_negro/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rio_negro/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/rio_negro/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/rio_negro/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/rio_negro/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/rio_negro/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
@@ -252,13 +214,9 @@
   {
    "id": "rivera",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rivera/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rivera/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rivera/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rivera/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rivera/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/rivera/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/rivera/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/rivera/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/rivera/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/rivera/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/rivera/barrio.topo.json",
@@ -273,12 +231,9 @@
   {
    "id": "rocha",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/rocha/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/rocha/opciones.json",
-    "votes": "/api/v1/results/internas-2024/rocha/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/rocha/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/rocha/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/rocha/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/rocha/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/rocha/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/rocha/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
@@ -292,13 +247,9 @@
   {
    "id": "salto",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/salto/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/salto/opciones.json",
-    "votes": "/api/v1/results/internas-2024/salto/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/salto/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/salto/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/salto/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/salto/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/salto/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/salto/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/salto/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/salto/barrio.topo.json",
@@ -313,13 +264,9 @@
   {
    "id": "san_jose",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/san_jose/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/san_jose/opciones.json",
-    "votes": "/api/v1/results/internas-2024/san_jose/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/san_jose/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/san_jose/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/san_jose/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/san_jose/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/san_jose/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/san_jose/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/san_jose/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/san_jose/barrio.topo.json",
@@ -334,12 +281,9 @@
   {
    "id": "soriano",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/soriano/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/soriano/opciones.json",
-    "votes": "/api/v1/results/internas-2024/soriano/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/soriano/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/soriano/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/soriano/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/soriano/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/soriano/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/soriano/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
@@ -353,12 +297,9 @@
   {
    "id": "tacuarembo",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/tacuarembo/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/tacuarembo/opciones.json",
-    "votes": "/api/v1/results/internas-2024/tacuarembo/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/tacuarembo/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/tacuarembo/votes-circuito.json",
-    "hoja-local": "/api/v1/results/internas-2024/tacuarembo/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/tacuarembo/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/tacuarembo/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/tacuarembo/votes.json"
    },
    "geo": {
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
@@ -372,13 +313,9 @@
   {
    "id": "treinta_y_tres",
    "results": {
-    "catalogo": "/api/v1/results/internas-2024/treinta_y_tres/catalogo.json",
-    "opciones": "/api/v1/results/internas-2024/treinta_y_tres/opciones.json",
-    "votes": "/api/v1/results/internas-2024/treinta_y_tres/votes.json",
-    "votes-local": "/api/v1/results/internas-2024/treinta_y_tres/votes-local.json",
-    "votes-circuito": "/api/v1/results/internas-2024/treinta_y_tres/votes-circuito.json",
-    "votes-barrio": "/api/v1/results/internas-2024/treinta_y_tres/votes-barrio.json",
-    "hoja-local": "/api/v1/results/internas-2024/treinta_y_tres/hoja-local.json"
+    "catalogo": "/api/v1/results/municipales-2025/treinta_y_tres/catalogo.json",
+    "opciones": "/api/v1/results/municipales-2025/treinta_y_tres/opciones.json",
+    "votes": "/api/v1/results/municipales-2025/treinta_y_tres/votes.json"
    },
    "geo": {
     "barrio.topo": "/api/v1/geo/treinta_y_tres/barrio.topo.json",

--- a/public/api/v1/elections/nacionales-2014.json
+++ b/public/api/v1/elections/nacionales-2014.json
@@ -2,6 +2,19 @@
  "id": "nacionales-2014",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/nacionales-2014/_nacional/opciones.json",
+    "votes": "/api/v1/results/nacionales-2014/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "catalogo": "/api/v1/results/nacionales-2014/artigas/catalogo.json",
@@ -16,6 +29,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -32,6 +47,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -50,6 +67,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -66,6 +85,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -84,6 +105,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -100,6 +123,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -116,6 +141,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -132,6 +159,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -148,6 +177,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -163,6 +194,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -181,6 +214,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -197,6 +232,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -215,6 +252,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -231,6 +270,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -249,6 +290,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -267,6 +310,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -283,6 +328,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -299,6 +346,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -317,6 +366,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/nacionales-2019.json
+++ b/public/api/v1/elections/nacionales-2019.json
@@ -2,6 +2,19 @@
  "id": "nacionales-2019",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/nacionales-2019/_nacional/opciones.json",
+    "votes": "/api/v1/results/nacionales-2019/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/nacionales-2019/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -142,6 +173,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -157,6 +190,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -171,6 +206,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -186,6 +223,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -200,6 +239,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -215,6 +256,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -230,6 +273,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -244,6 +289,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -258,6 +305,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -273,6 +322,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/nacionales-2024.json
+++ b/public/api/v1/elections/nacionales-2024.json
@@ -2,6 +2,19 @@
  "id": "nacionales-2024",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/nacionales-2024/_nacional/opciones.json",
+    "votes": "/api/v1/results/nacionales-2024/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "catalogo": "/api/v1/results/nacionales-2024/artigas/catalogo.json",
@@ -16,6 +29,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -32,6 +47,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -50,6 +67,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -66,6 +85,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -84,6 +105,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -100,6 +123,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -116,6 +141,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -132,6 +159,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -148,6 +177,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -163,6 +194,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -181,6 +214,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -197,6 +232,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -215,6 +252,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -231,6 +270,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -249,6 +290,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -267,6 +310,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -283,6 +328,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -299,6 +346,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -317,6 +366,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/plebiscito-allanamientos-2024.json
+++ b/public/api/v1/elections/plebiscito-allanamientos-2024.json
@@ -2,6 +2,19 @@
  "id": "plebiscito-allanamientos-2024",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/plebiscito-allanamientos-2024/_nacional/opciones.json",
+    "votes": "/api/v1/results/plebiscito-allanamientos-2024/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/plebiscito-allanamientos-2024/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/plebiscito-seguridad-social-2024.json
+++ b/public/api/v1/elections/plebiscito-seguridad-social-2024.json
@@ -2,6 +2,19 @@
  "id": "plebiscito-seguridad-social-2024",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/plebiscito-seguridad-social-2024/_nacional/opciones.json",
+    "votes": "/api/v1/results/plebiscito-seguridad-social-2024/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/plebiscito-seguridad-social-2024/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/plebiscito-vivir-sin-miedo-2019.json
+++ b/public/api/v1/elections/plebiscito-vivir-sin-miedo-2019.json
@@ -2,6 +2,19 @@
  "id": "plebiscito-vivir-sin-miedo-2019",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/plebiscito-vivir-sin-miedo-2019/_nacional/opciones.json",
+    "votes": "/api/v1/results/plebiscito-vivir-sin-miedo-2019/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/plebiscito-vivir-sin-miedo-2019/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -140,6 +171,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -155,6 +188,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -169,6 +204,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -184,6 +221,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -198,6 +237,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -213,6 +254,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -228,6 +271,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -242,6 +287,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -256,6 +303,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -271,6 +320,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/elections/referendum-luc-2022.json
+++ b/public/api/v1/elections/referendum-luc-2022.json
@@ -2,6 +2,19 @@
  "id": "referendum-luc-2022",
  "departamentos": [
   {
+   "id": "_nacional",
+   "results": {
+    "opciones": "/api/v1/results/referendum-luc-2022/_nacional/opciones.json",
+    "votes": "/api/v1/results/referendum-luc-2022/_nacional/votes.json"
+   },
+   "geo": {
+    "departamento.topo": "/api/v1/geo/_nacional/departamento.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/_nacional/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/_nacional/municipio.topo.json",
+    "zona.topo": "/api/v1/geo/_nacional/zona.topo.json"
+   }
+  },
+  {
    "id": "artigas",
    "results": {
     "opciones": "/api/v1/results/referendum-luc-2022/artigas/opciones.json",
@@ -13,6 +26,8 @@
     "circuito.topo": "/api/v1/geo/artigas/circuito.topo.json",
     "local.topo": "/api/v1/geo/artigas/local.topo.json",
     "localidad.topo": "/api/v1/geo/artigas/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/artigas/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/artigas/municipio.topo.json",
     "serie.topo": "/api/v1/geo/artigas/serie.topo.json"
    }
   },
@@ -27,6 +42,8 @@
     "circuito.topo": "/api/v1/geo/canelones/circuito.topo.json",
     "local.topo": "/api/v1/geo/canelones/local.topo.json",
     "localidad.topo": "/api/v1/geo/canelones/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/canelones/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/canelones/municipio.topo.json",
     "serie.topo": "/api/v1/geo/canelones/serie.topo.json"
    }
   },
@@ -42,6 +59,8 @@
     "circuito.topo": "/api/v1/geo/cerro_largo/circuito.topo.json",
     "local.topo": "/api/v1/geo/cerro_largo/local.topo.json",
     "localidad.topo": "/api/v1/geo/cerro_largo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/cerro_largo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/cerro_largo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/cerro_largo/serie.topo.json"
    }
   },
@@ -56,6 +75,8 @@
     "circuito.topo": "/api/v1/geo/colonia/circuito.topo.json",
     "local.topo": "/api/v1/geo/colonia/local.topo.json",
     "localidad.topo": "/api/v1/geo/colonia/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/colonia/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/colonia/municipio.topo.json",
     "serie.topo": "/api/v1/geo/colonia/serie.topo.json"
    }
   },
@@ -71,6 +92,8 @@
     "circuito.topo": "/api/v1/geo/durazno/circuito.topo.json",
     "local.topo": "/api/v1/geo/durazno/local.topo.json",
     "localidad.topo": "/api/v1/geo/durazno/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/durazno/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/durazno/municipio.topo.json",
     "serie.topo": "/api/v1/geo/durazno/serie.topo.json"
    }
   },
@@ -85,6 +108,8 @@
     "circuito.topo": "/api/v1/geo/flores/circuito.topo.json",
     "local.topo": "/api/v1/geo/flores/local.topo.json",
     "localidad.topo": "/api/v1/geo/flores/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/flores/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/flores/municipio.topo.json",
     "serie.topo": "/api/v1/geo/flores/serie.topo.json"
    }
   },
@@ -99,6 +124,8 @@
     "circuito.topo": "/api/v1/geo/florida/circuito.topo.json",
     "local.topo": "/api/v1/geo/florida/local.topo.json",
     "localidad.topo": "/api/v1/geo/florida/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/florida/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/florida/municipio.topo.json",
     "serie.topo": "/api/v1/geo/florida/serie.topo.json"
    }
   },
@@ -113,6 +140,8 @@
     "circuito.topo": "/api/v1/geo/lavalleja/circuito.topo.json",
     "local.topo": "/api/v1/geo/lavalleja/local.topo.json",
     "localidad.topo": "/api/v1/geo/lavalleja/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/lavalleja/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/lavalleja/municipio.topo.json",
     "serie.topo": "/api/v1/geo/lavalleja/serie.topo.json"
    }
   },
@@ -127,6 +156,8 @@
     "circuito.topo": "/api/v1/geo/maldonado/circuito.topo.json",
     "local.topo": "/api/v1/geo/maldonado/local.topo.json",
     "localidad.topo": "/api/v1/geo/maldonado/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/maldonado/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/maldonado/municipio.topo.json",
     "serie.topo": "/api/v1/geo/maldonado/serie.topo.json"
    }
   },
@@ -141,6 +172,8 @@
    "geo": {
     "circuito.topo": "/api/v1/geo/montevideo/circuito.topo.json",
     "local.topo": "/api/v1/geo/montevideo/local.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/montevideo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/montevideo/municipio.topo.json",
     "zona.topo": "/api/v1/geo/montevideo/zona.topo.json"
    }
   },
@@ -156,6 +189,8 @@
     "circuito.topo": "/api/v1/geo/paysandu/circuito.topo.json",
     "local.topo": "/api/v1/geo/paysandu/local.topo.json",
     "localidad.topo": "/api/v1/geo/paysandu/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/paysandu/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/paysandu/municipio.topo.json",
     "serie.topo": "/api/v1/geo/paysandu/serie.topo.json"
    }
   },
@@ -170,6 +205,8 @@
     "circuito.topo": "/api/v1/geo/rio_negro/circuito.topo.json",
     "local.topo": "/api/v1/geo/rio_negro/local.topo.json",
     "localidad.topo": "/api/v1/geo/rio_negro/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rio_negro/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rio_negro/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rio_negro/serie.topo.json"
    }
   },
@@ -185,6 +222,8 @@
     "circuito.topo": "/api/v1/geo/rivera/circuito.topo.json",
     "local.topo": "/api/v1/geo/rivera/local.topo.json",
     "localidad.topo": "/api/v1/geo/rivera/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rivera/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rivera/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rivera/serie.topo.json"
    }
   },
@@ -199,6 +238,8 @@
     "circuito.topo": "/api/v1/geo/rocha/circuito.topo.json",
     "local.topo": "/api/v1/geo/rocha/local.topo.json",
     "localidad.topo": "/api/v1/geo/rocha/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/rocha/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/rocha/municipio.topo.json",
     "serie.topo": "/api/v1/geo/rocha/serie.topo.json"
    }
   },
@@ -214,6 +255,8 @@
     "circuito.topo": "/api/v1/geo/salto/circuito.topo.json",
     "local.topo": "/api/v1/geo/salto/local.topo.json",
     "localidad.topo": "/api/v1/geo/salto/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/salto/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/salto/municipio.topo.json",
     "serie.topo": "/api/v1/geo/salto/serie.topo.json"
    }
   },
@@ -229,6 +272,8 @@
     "circuito.topo": "/api/v1/geo/san_jose/circuito.topo.json",
     "local.topo": "/api/v1/geo/san_jose/local.topo.json",
     "localidad.topo": "/api/v1/geo/san_jose/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/san_jose/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/san_jose/municipio.topo.json",
     "serie.topo": "/api/v1/geo/san_jose/serie.topo.json"
    }
   },
@@ -243,6 +288,8 @@
     "circuito.topo": "/api/v1/geo/soriano/circuito.topo.json",
     "local.topo": "/api/v1/geo/soriano/local.topo.json",
     "localidad.topo": "/api/v1/geo/soriano/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/soriano/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/soriano/municipio.topo.json",
     "serie.topo": "/api/v1/geo/soriano/serie.topo.json"
    }
   },
@@ -257,6 +304,8 @@
     "circuito.topo": "/api/v1/geo/tacuarembo/circuito.topo.json",
     "local.topo": "/api/v1/geo/tacuarembo/local.topo.json",
     "localidad.topo": "/api/v1/geo/tacuarembo/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/tacuarembo/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/tacuarembo/municipio.topo.json",
     "serie.topo": "/api/v1/geo/tacuarembo/serie.topo.json"
    }
   },
@@ -272,6 +321,8 @@
     "circuito.topo": "/api/v1/geo/treinta_y_tres/circuito.topo.json",
     "local.topo": "/api/v1/geo/treinta_y_tres/local.topo.json",
     "localidad.topo": "/api/v1/geo/treinta_y_tres/localidad.topo.json",
+    "municipio.2020.topo": "/api/v1/geo/treinta_y_tres/municipio.2020.topo.json",
+    "municipio.topo": "/api/v1/geo/treinta_y_tres/municipio.topo.json",
     "serie.topo": "/api/v1/geo/treinta_y_tres/serie.topo.json"
    }
   }

--- a/public/api/v1/index.json
+++ b/public/api/v1/index.json
@@ -35,6 +35,8 @@
   "departamentales-2025",
   "internas-2019",
   "internas-2024",
+  "municipales-2020",
+  "municipales-2025",
   "nacionales-2014",
   "nacionales-2019",
   "nacionales-2024",

--- a/public/api/v1/openapi.json
+++ b/public/api/v1/openapi.json
@@ -10,6 +10,7 @@
   "tags": [
     { "name": "Descubrimiento", "description": "Índices para navegar la API." },
     { "name": "Resultados", "description": "Votos por zona y geometría por departamento." },
+    { "name": "Municipales", "description": "Elecciones municipales (municipales-2025, municipales-2020): nivel municipio, alcalde electo y Concejo Municipal (alcalde + 4 concejales) por adjudicación D'Hondt, validado contra las actas de proclamación." },
     { "name": "Candidatos", "description": "Personas candidatas y votos de las listas que integran (legisladores)." }
   ],
   "paths": {
@@ -27,7 +28,7 @@
           "elections": "/api/v1/elections.json",
           "candidatos": "/api/v1/candidatos/index.json",
           "departamentos": ["artigas", "canelones", "montevideo", "salto", "…"],
-          "elecciones": ["balotaje-2024", "nacionales-2024", "departamentales-2025", "…"]
+          "elecciones": ["balotaje-2024", "nacionales-2024", "departamentales-2025", "municipales-2025", "municipales-2020", "…"]
         } } } } }
       }
     },
@@ -97,11 +98,50 @@
         } } } } }
       }
     },
+    "/api/v1/results/{eleccion}/_nacional/alcaldes.json": {
+      "get": {
+        "tags": ["Municipales"],
+        "summary": "Alcalde electo por municipio (municipales)",
+        "description": "Solo para elecciones municipales. Alcalde = primer titular de la lista más votada del lema más votado (Ley 19.272). Clave: geoId nacional compuesto «MUNICIPIO · Departamento». En Montevideo el municipio es una letra (A–G, CH) → «Municipio X».",
+        "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string", "enum": ["municipales-2025", "municipales-2020"] }, "example": "municipales-2025" }],
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "eleccion": "municipales-2025",
+          "regla": "Alcalde = primer titular de la lista más votada del lema más votado (Ley 19.272).",
+          "municipios": {
+            "Municipio CH · Montevideo": {
+              "municipio": "Municipio CH", "departamento": "montevideo", "ganadorLema": "coalicion-republicana",
+              "alcaldeElecto": { "nombre": "MATILDE ANTIA ADAMI", "lema": "coalicion-republicana", "hoja": "40-CH", "votosLista": 28000 }
+            }
+          }
+        } } } } }
+      }
+    },
+    "/api/v1/results/{eleccion}/_nacional/concejos.json": {
+      "get": {
+        "tags": ["Municipales"],
+        "summary": "Concejo Municipal (alcalde + 4 concejales)",
+        "description": "Solo para elecciones municipales. Los 5 cargos del Concejo por adjudicación D'Hondt (lema→sublema→lista→ordinal; sin mayoría automática). Nombres de la integración de hojas. Validado contra las actas de proclamación; donde el cálculo difería del acta (empate por sorteo, voto-al-sublema, sustitución de candidato) se fija el Concejo proclamado.",
+        "parameters": [{ "name": "eleccion", "in": "path", "required": true, "schema": { "type": "string", "enum": ["municipales-2025", "municipales-2020"] }, "example": "municipales-2025" }],
+        "responses": { "200": { "description": "OK", "content": { "application/json": { "example": {
+          "regla": "Concejo de 5: D'Hondt lema→sublema→lista→ordinal. mayoriaAutomatica=False.",
+          "municipios": {
+            "Municipio CH · Montevideo": {
+              "municipio": "Municipio CH", "departamento": "montevideo",
+              "concejo": [
+                { "cargo": "alcalde", "nombre": "MATILDE ANTIA ADAMI", "lema": "coalicion-republicana", "hoja": "40-CH" },
+                { "cargo": "concejal", "nombre": "JOSE FELIX LLANES SANTANA", "lema": "coalicion-republicana", "hoja": "40-CH" },
+                { "cargo": "concejal", "nombre": "MONICA SILVANA CAFFA REYES", "lema": "frente-amplio", "hoja": "79-CH" }
+              ]
+            }
+          }
+        } } } } }
+      }
+    },
     "/api/v1/geo/{departamento}/{nivel}.topo.json": {
       "get": {
         "tags": ["Resultados"],
         "summary": "Geometría TopoJSON",
-        "description": "Geometría del departamento en formato TopoJSON para el nivel pedido (zona/barrio, circuito, local, serie, localidad). Los `geoId` cruzan con los de `votes.json`.",
+        "description": "Geometría del departamento en formato TopoJSON para el nivel pedido (zona/barrio, circuito, local, serie, localidad, municipio). Los `geoId` cruzan con los de `votes.json`. El nivel `municipio` cambia por ciclo: 2025 = `municipio.topo.json`; otros ciclos = `municipio.{año}.topo.json` (p.ej. `municipio.2020.topo.json`).",
         "parameters": [
           { "name": "departamento", "in": "path", "required": true, "schema": { "type": "string" }, "example": "montevideo" },
           { "name": "nivel", "in": "path", "required": true, "schema": { "type": "string" }, "example": "zona" }

--- a/scripts/build-api-index.py
+++ b/scripts/build-api-index.py
@@ -9,7 +9,9 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA = os.path.join(ROOT, 'public/data')
 OUT = os.path.join(ROOT, 'public/api/v1')
 RESULT_FILES = ['catalogo.json', 'opciones.json', 'votes.json', 'votes-local.json',
-                'votes-circuito.json', 'votes-barrio.json', 'hoja-local.json']
+                'votes-circuito.json', 'votes-barrio.json', 'hoja-local.json',
+                # Municipales (Epic 22): recursos nacionales — alcalde electo + Concejo Municipal por municipio.
+                'alcaldes.json', 'concejos.json']
 
 def depts():
     return json.load(open(os.path.join(ROOT, 'src/config/departments.json'), encoding='utf-8'))
@@ -52,6 +54,9 @@ def main():
     json.dump({"elecciones": elist}, open(os.path.join(OUT, 'elections.json'), 'w', encoding='utf-8'), ensure_ascii=False, indent=1)
     for e in sorted(elections):
         detalle = {"id": e, "departamentos": []}
+        # Vista nacional: agregados + recursos solo-nacionales (alcaldes/concejos en municipales).
+        if os.path.isdir(os.path.join(DATA, e, '_nacional')):
+            detalle["departamentos"].append({"id": "_nacional", "results": resources_for(e, '_nacional'), "geo": geo_for('_nacional')})
         for depto in sorted(set(elections[e])):
             detalle["departamentos"].append({"id": depto, "results": resources_for(e, depto), "geo": geo_for(depto)})
         json.dump(detalle, open(os.path.join(OUT, 'elections', f'{e}.json'), 'w', encoding='utf-8'), ensure_ascii=False, indent=1)


### PR DESCRIPTION
## Qué

Actualiza la **API pública v1** con todo lo agregado esta sesión (Concejos, Municipales 2025 con Montevideo, Municipales 2020).

- **Descubrimiento**: `index.json` / `elections.json` / `elections/*.json` ahora incluyen `municipales-2025` y `municipales-2020` (16 elecciones). Se expone la vista **`_nacional`** por elección (donde viven el alcalde y el Concejo de las municipales).
- **Nuevos recursos**: `alcaldes.json` y `concejos.json` agregados a los recursos descubribles (`build-api-index.py`).
- **Dumps NDJSON**: `municipales-2025` (359 filas) y `municipales-2020` (433 filas).
- **OpenAPI**: tag **Municipales** + paths `/api/v1/results/{eleccion}/_nacional/{alcaldes,concejos}.json` con ejemplos; `geo` documenta el nivel `municipio` por ciclo (`municipio.{año}.topo.json`).

## Verificación
- `node scripts/gate-api-contract.mjs`: contrato v1 OK.
- Vitest `src/api/api-contract.test.ts`: **13/13** en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)