### PR TITLE
feat(ux): control arriba del mapa + paneles plegables (control, resultado, ficha)

### DIFF
--- a/src/components/map/ResultadoGlobal.vue
+++ b/src/components/map/ResultadoGlobal.vue
@@ -7,6 +7,7 @@
  * El % usa el mismo denominador que la ficha (votos válidos), así reconcilian entre sí.
  */
 import { computed } from 'vue';
+import { useCollapsible } from '../../lib/use-collapsible';
 
 interface Entrada {
   readonly opcionId: string;
@@ -42,14 +43,29 @@ const otros = computed(() => {
   const pct = resto.reduce((s, e) => s + e.pct, 0);
   return { n: resto.length, votos, pct };
 });
+
+// Plegable (Epic UX): el resultado arranca ABIERTO; el usuario puede esconderlo.
+const { open, toggle } = useCollapsible('resultado', true);
+// Resumen de una línea cuando está colapsado (las 2 opciones más votadas).
+const resumen = computed(() =>
+  props.entradas.slice(0, 2).map((e) => `${e.sigla} ${e.pct.toFixed(1)}%`).join(' · '));
 </script>
 
 <template>
   <div v-if="entradas.length > 0" class="resultado" aria-label="Resultado agregado">
-    <h2 class="resultado__titulo">
-      {{ titulo }}<span v-if="contexto" class="resultado__contexto"> · {{ contexto }}</span>
-    </h2>
-    <ul class="resultado__lista">
+    <button
+      type="button"
+      class="resultado__toggle"
+      :aria-expanded="open"
+      @click="toggle"
+    >
+      <span class="resultado__chevron" :class="{ 'resultado__chevron--open': open }" aria-hidden="true">▸</span>
+      <h2 class="resultado__titulo">
+        {{ titulo }}<span v-if="contexto" class="resultado__contexto"> · {{ contexto }}</span>
+      </h2>
+      <span v-if="!open" class="resultado__resumen">{{ resumen }}</span>
+    </button>
+    <ul v-show="open" class="resultado__lista">
       <li v-for="e in visibles" :key="e.opcionId" class="resultado__fila">
         <img
           v-if="e.flagUrl"
@@ -79,7 +95,7 @@ const otros = computed(() => {
         <span class="resultado__pct">{{ otros.pct.toFixed(1) }}%</span>
       </li>
     </ul>
-    <p class="resultado__pie">{{ fmt(validos) }} votos válidos</p>
+    <p v-show="open" class="resultado__pie">{{ fmt(validos) }} votos válidos</p>
   </div>
 </template>
 
@@ -89,13 +105,41 @@ const otros = computed(() => {
   border-top: 1px solid var(--color-border);
   padding: 0.75rem 1rem;
 }
+.resultado__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+.resultado__chevron {
+  color: var(--color-ink-faint);
+  font-size: 0.75rem;
+  transition: transform 0.15s ease;
+  flex: none;
+}
+.resultado__chevron--open { transform: rotate(90deg); }
 .resultado__titulo {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.03em;
   color: var(--color-ink-muted);
-  margin: 0 0 0.5rem;
+  margin: 0;
+}
+.resultado__resumen {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-ink-soft);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 .resultado__contexto { font-weight: 600; color: var(--color-ink-soft); text-transform: none; letter-spacing: 0; }
 .resultado__lista {

--- a/src/components/selectors/OpcionAccordion.vue
+++ b/src/components/selectors/OpcionAccordion.vue
@@ -11,6 +11,10 @@
 import { onMounted, ref, computed, onUnmounted } from 'vue';
 import { resolveParty } from '../../lib/party-meta';
 import { $selection, commit } from '../../stores/map-state';
+import { useCollapsible } from '../../lib/use-collapsible';
+
+// Plegable (Epic UX): el control de listas arranca COLAPSADO (es avanzado); el usuario lo abre.
+const { open: panelOpen, toggle: togglePanel } = useCollapsible('opcion', false);
 
 const props = defineProps<{ eleccion: string; departamento: string }>();
 
@@ -365,6 +369,20 @@ const flagLema  = (l: NodoOpcion): string | null => resolveParty(l.etiqueta).fla
 
 <template>
   <section class="acc" aria-label="Selector de opción (granularidad)">
+    <!-- Header plegable (Epic UX): el control arranca colapsado; al abrir aparece el selector. -->
+    <button
+      v-if="contienda"
+      type="button"
+      class="acc__toggle"
+      :aria-expanded="panelOpen"
+      @click="togglePanel"
+    >
+      <span class="acc__toggle-chevron" :class="{ 'acc__toggle-chevron--open': panelOpen }" aria-hidden="true">▸</span>
+      <span class="acc__toggle-lbl">Filtrar por lista / partido</span>
+      <span v-if="!panelOpen && seleccion.size > 0" class="acc__toggle-badge">{{ seleccion.size }} sel.</span>
+    </button>
+
+    <div v-show="panelOpen || !contienda" class="acc__body">
     <!-- Selector de contienda (solo si hay >1) -->
     <div v-if="tieneVariasContiendas" class="acc__contiendas" role="tablist" aria-label="Contienda">
       <button
@@ -563,11 +581,28 @@ const flagLema  = (l: NodoOpcion): string | null => resolveParty(l.etiqueta).fla
     </ul>
 
     <p v-if="!catalogo" class="acc__cargando">Cargando opciones…</p>
+    </div>
   </section>
 </template>
 
 <style scoped>
 .acc { padding: 0.5rem 1rem; border-bottom: 1px solid var(--color-border); font-size: 0.875rem; }
+.acc__toggle {
+  display: flex; align-items: center; gap: 0.5rem; width: 100%;
+  background: none; border: none; padding: 0.25rem 0; margin: 0; cursor: pointer;
+  text-align: left; color: inherit; min-height: 36px;
+}
+.acc__toggle-chevron { color: var(--color-ink-faint); font-size: 0.75rem; transition: transform 0.15s ease; flex: none; }
+.acc__toggle-chevron--open { transform: rotate(90deg); }
+.acc__toggle-lbl {
+  font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+  color: var(--color-ink-muted);
+}
+.acc__toggle-badge {
+  margin-left: auto; font-size: 0.6875rem; font-weight: 700; color: var(--color-paper);
+  background: var(--color-ink); border-radius: 9999px; padding: 0.0625rem 0.5rem;
+}
+.acc__body { margin-top: 0.5rem; }
 .acc__contiendas { display: flex; gap: 0.25rem; margin-bottom: 0.5rem; }
 .acc__contienda {
   flex: 1; padding: 0.375rem 0.5rem; border: 1px solid var(--color-border-strong);

--- a/src/components/sheet/ZoneSheet.vue
+++ b/src/components/sheet/ZoneSheet.vue
@@ -3,6 +3,7 @@
  * Ficha de zona (Story 2.4). Bottom sheet en mobile, panel lateral en desktop.
  * Muestra ganador, votos, %, blanco/anulados/observados para la zona seleccionada.
  */
+import { ref, watch } from 'vue';
 
 interface DesgloseGrupo {
   lemaNombre: string;
@@ -60,6 +61,11 @@ const props = defineProps<{
   sel: SelInfo | null;
   opcionSigla: string | null;
 }>();
+
+// Plegable (Epic UX): el detalle de la zona seleccionada se puede esconder. Se reabre al
+// seleccionar otra zona (es información on-demand). No persiste (efímero por selección).
+const bodyOpen = ref(true);
+watch(() => props.sel?.geoId, () => { bodyOpen.value = true; });
 
 const emit = defineEmits<{ close: [] }>();
 
@@ -124,6 +130,13 @@ function pctEmit(n: number): string {
       <div class="zone-sheet__handle" aria-hidden="true"></div>
 
       <header class="zone-sheet__header">
+        <button
+          class="zone-sheet__plegar"
+          type="button"
+          :aria-expanded="bodyOpen"
+          :aria-label="bodyOpen ? 'Plegar detalle' : 'Desplegar detalle'"
+          @click="bodyOpen = !bodyOpen"
+        ><span class="zone-sheet__chevron" :class="{ 'zone-sheet__chevron--open': bodyOpen }" aria-hidden="true">▸</span></button>
         <h2 class="zone-sheet__titulo">{{ sel.label ?? sel.geoId }}</h2>
         <button
           class="zone-sheet__cerrar"
@@ -144,7 +157,7 @@ function pctEmit(n: number): string {
         Vista por barrio no disponible aún — mostrando resultado agregado de la ciudad
       </p>
 
-      <div class="zone-sheet__body">
+      <div v-show="bodyOpen" class="zone-sheet__body">
         <!-- Desglose por hoja de la selección (Epic 10, Story 10.5) -->
         <template v-if="sel.desglose && sel.desglose.length > 0">
           <div class="zone-sheet__sel-resumen">
@@ -379,11 +392,27 @@ function pctEmit(n: number): string {
   border-bottom: 1px solid var(--color-surface-2);
 }
 
+.zone-sheet__plegar {
+  background: none;
+  border: none;
+  padding: 0 0.5rem 0 0;
+  margin: 0;
+  cursor: pointer;
+  color: var(--color-ink-faint);
+  flex: none;
+}
+.zone-sheet__chevron {
+  display: inline-block;
+  font-size: 0.8125rem;
+  transition: transform 0.15s ease;
+}
+.zone-sheet__chevron--open { transform: rotate(90deg); }
 .zone-sheet__titulo {
   font-size: 1rem;
   font-weight: 700;
   color: var(--color-ink);
   margin: 0;
+  margin-right: auto;
 }
 
 .zone-sheet__cerrar {

--- a/src/lib/use-collapsible.ts
+++ b/src/lib/use-collapsible.ts
@@ -1,0 +1,21 @@
+import { ref, watch, type Ref } from 'vue';
+
+/**
+ * Estado plegado/desplegado persistido en localStorage (por clave), para que el usuario pueda
+ * esconder paneles (control de listas, resultado) y la preferencia sobreviva la navegación.
+ * SSR-safe: en el server arranca con `defaultOpen` y no toca localStorage.
+ */
+export function useCollapsible(key: string, defaultOpen: boolean): { open: Ref<boolean>; toggle: () => void } {
+  const storageKey = `ui:collapse:${key}`;
+  let initial = defaultOpen;
+  if (typeof window !== 'undefined') {
+    const v = window.localStorage.getItem(storageKey);
+    if (v === '0') initial = false;
+    else if (v === '1') initial = true;
+  }
+  const open = ref(initial);
+  watch(open, (o) => {
+    if (typeof window !== 'undefined') window.localStorage.setItem(storageKey, o ? '1' : '0');
+  });
+  return { open, toggle: () => { open.value = !open.value; } };
+}

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -145,7 +145,10 @@ const canonicalPath = `/${eleccion}/${departamento}`;
       availableElecciones={availableElecciones}
       eleccionActual={eleccion}
     />
-    <!-- Map-first: el mapa (héroe) va arriba de los selectores para quedar visible sin scrollear.
+    <!-- Control de listas/partido (Epic UX): ARRIBA del mapa, plegable y colapsado por defecto
+         (decisión de Juan). Sincroniza con el mapa por el store, así que su posición no afecta. -->
+    <OpcionAccordion client:idle eleccion={eleccion} departamento={departamento} />
+    <!-- Map-first: el mapa (héroe) queda visible sin scrollear (el control de arriba va colapsado).
          transition:persist con nombre ESTABLE ("map") → el island MapLibre sobrevive la navegación
          entre departamentos aunque vaya antes en el DOM (NFR1). -->
     <div id="map-persist" transition:persist="map">
@@ -156,8 +159,6 @@ const canonicalPath = `/${eleccion}/${departamento}`;
         availableLevels={availableLevels}
       />
     </div>
-    <!-- Selector de opción (listas) — debajo del mapa (isla fuera de persist, se re-monta, Story 2.2) -->
-    <OpcionAccordion client:idle eleccion={eleccion} departamento={departamento} />
     <div class="share-actions">
       <ExportButton client:idle eleccion={eleccion} departamento={departamento} />
       <MapScreenshotButton

--- a/src/pages/[eleccion]/index.astro
+++ b/src/pages/[eleccion]/index.astro
@@ -107,6 +107,8 @@ const canonicalPath = `/${eleccion}`;
     <!-- Toggle Departamentos/Zonas — control del mapa: va PEGADO arriba del mapa (Story 15.4).
          No aplica a Municipales (nivel único 'municipio'). -->
     {!esMunicipales && <GranularitySelector client:idle />}
+    <!-- Control de listas/partido (Epic UX): ARRIBA del mapa, plegable y colapsado por defecto. -->
+    <OpcionAccordion client:idle eleccion={eleccion} departamento="_nacional" />
     <!-- Map-first: el mapa va arriba de los selectores para quedar visible sin scrollear.
          persist con nombre propio ("map-nacional") → persiste entre elecciones nacionales pero
          NO cruza con la vista por-depto (que debe re-inicializar). -->
@@ -119,8 +121,6 @@ const canonicalPath = `/${eleccion}`;
         defaultNivel={nacDefaultNivel}
       />
     </div>
-    <!-- Selector de opción (listas) — debajo del mapa -->
-    <OpcionAccordion client:idle eleccion={eleccion} departamento="_nacional" />
     <Sello eleccion={eleccion} departamento="_nacional" />
   </main>
 </Base>


### PR DESCRIPTION
## Audit UX + cambios (lente Sally/BMAD)

**Problema:** scroll largo con todo apilado bajo el mapa y nada plegable; el control de listas quedaba enterrado al fondo.

**Cambios (decididos con Juan):**
- **Control de listas/partido** (`OpcionAccordion`): de **debajo** a **arriba** del mapa, **plegable y colapsado por defecto** (header "Filtrar por lista / partido" + badge con nº de seleccionadas). Sincroniza por el store → la posición no afecta el comportamiento.
- **Resultado global** (`ResultadoGlobal`): plegable, **abierto por defecto**, con resumen de una línea (`FA 50.8% · CR 48.6%`) al colapsar.
- **Ficha de zona seleccionada** (`ZoneSheet`): chevron para plegar el detalle (se reabre al elegir otra zona).
- **`useCollapsible`**: composable que **persiste** el estado en localStorage por panel.

Mantiene `map-first` (el mapa queda visible sin scroll porque el control arranca colapsado).

## Verificación
- `npm run check`: 0 errores. Tests OpcionAccordion (2/2) y contrato API (13/13) en verde.
- Navegador: los 3 toggles funcionan y persisten; ficha de Municipio C pliega/despliega.

🤖 Generated with [Claude Code](https://claude.com/claude-code)