### PR TITLE
fix(ux): Municipales 2020 en su lugar cronológico en el timeline

### DIFF
--- a/src/components/selectors/EleccionSelector.vue
+++ b/src/components/selectors/EleccionSelector.vue
@@ -24,6 +24,7 @@ const META: Record<string, { short: string; type: TipoEleccion; año: number }> 
   'plebiscito-vivir-sin-miedo-2019':  { short: 'Vivir sin Miedo',  type: 'plebiscito',  año: 2019 },
   'balotaje-2019':                    { short: 'Balotaje',         type: 'balotaje',    año: 2019 },
   'departamentales-2020':             { short: 'Departamentales',  type: 'dptales',     año: 2020 },
+  'municipales-2020':                 { short: 'Municipales',      type: 'dptales',     año: 2020 },
   'referendum-luc-2022':              { short: 'Referéndum LUC',   type: 'plebiscito',  año: 2022 },
   'internas-2024':                    { short: 'Internas',         type: 'internas',    año: 2024 },
   'nacionales-2024':                  { short: 'Nacionales',       type: 'nacionales',  año: 2024 },
@@ -32,7 +33,6 @@ const META: Record<string, { short: string; type: TipoEleccion; año: number }> 
   'balotaje-2024':                    { short: 'Balotaje',         type: 'balotaje',    año: 2024 },
   'departamentales-2025':             { short: 'Departamentales',  type: 'dptales',     año: 2025 },
   'municipales-2025':                 { short: 'Municipales',      type: 'dptales',     año: 2025 },
-  'municipales-2020':                 { short: 'Municipales',      type: 'dptales',     año: 2020 },
 };
 
 const ALL_IDS = Object.keys(META);


### PR DESCRIPTION
El timeline agrupa por orden de inserción en META (años consecutivos). `municipales-2020` estaba al final (tras 2025) → grupo 2020 suelto al final. Se mueve junto a `departamentales-2020` → queda `… 2019 · 2020 · 2022 …`. Verificado en navegador (orden de años: 2014·2019·2020·2022·2024·2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)