### PR TITLE
fix(map): municipales mostraba barrios grises al navegar in-app desde departamental

### DIFF
--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2299,6 +2299,10 @@ const unsubSelection = $selection.subscribe((s) => {
 
 /** Resuelve el nivel base efectivo: excluye 'circuito' (ahora es overlay, no nivel base). */
 function resolveNivel(urlLevel: NivelGeografico, dept?: string): NivelGeografico {
+  // Election-aware: las municipales tienen nivel ÚNICO 'municipio'. DEPT_LEVELS es por-DEPTO (no por
+  // elección) → al navegar in-app desde una departamental (zona/serie) resolvería mal y cargaría la
+  // geometría vieja (barrios) con votos de municipio = todo gris. Forzar 'municipio' lo evita.
+  if (activeEleccion?.startsWith('municipales')) return 'municipio' as NivelGeografico;
   const avail = (dept ? DEPT_LEVELS[dept] : null) ?? props.availableLevels ?? (['zona'] as NivelGeografico[]);
   const base = avail.filter(l => l !== 'circuito' && l !== 'local');
   const valid = base.length > 0 ? base : avail;


### PR DESCRIPTION
Bug reportado: al ir de una departamental a Municipales por el timeline, el mapa quedaba con barrios grises (geometría del depto anterior + votos municipio sin join). Causa: `resolveNivel` no era election-aware (usaba DEPT_LEVELS por-depto → 'zona' en vez de 'municipio') al recargar en `astro:after-swap` con el island persistido. Fix: forzar 'municipio' para municipales. Verificado: depto→Municipales = 8 municipios coloreados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)