### PR TITLE
feat(ux): Epic 23 — Rediseño UX 'Atlas Electoral' (WIP)

### DIFF
--- a/docs/flags-backup/cr-clasica.svg
+++ b/docs/flags-backup/cr-clasica.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 60">
+  <!-- Coalición Republicana: blanco con barras roja+azul y estrella amarilla, emblema CENTRADO -->
+  <rect x="0" y="0" width="90" height="60" fill="#FFFFFF"/>
+  <rect x="36" y="20" width="9" height="32" fill="#FD0000"/>
+  <rect x="45" y="20" width="9" height="32" fill="#000163"/>
+  <path fill="#FFD400" d="M50 5 L51.65 9.74 L56.66 9.84 L52.66 12.87 L54.11 17.66 L50 14.8 L45.89 17.66 L47.34 12.87 L43.34 9.84 L48.35 9.74 Z"/>
+</svg>

--- a/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
+++ b/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
@@ -86,7 +86,16 @@ Rama `feat/epic-23-ux-redesign`. Todo verificado en browser (Playwright) + `npm 
 | 23.2 layout workspace 2-columnas (mapa + rail sticky) | ✅ | `11417c3` |
 | 23.5 dark mode toggle manual (claro/oscuro/auto, anti-flash) | ✅ | `e352df6` |
 | 23.3 rail de resultados como card | ✅ | `ff9a8be` |
-| 23.4 mapa: badge de leyenda overlay + tooltip on-brand (zoom ya existe) | ⏳ pendiente | |
-| 23.6 timeline con nodos conectados (re-skin EleccionSelector) | ⏳ pendiente | |
+| 23.4 mapa: zoom on-brand + tooltip al hover (nombre + ganador) | ✅ | `9128895`, `957216d` |
+| 23.6 timeline con nodos conectados | ✅ ya satisfecho | — |
+
+**Sobre 23.6:** `EleccionSelector.vue` YA es un timeline más rico que el del mockup (grupos por
+año + rieles conectores + dots con forma por tipo de elección [círculo/rombo/cuadrado] +
+activo con dot relleno/anillo/pill + fades + drag-scroll + leyenda de formas). Re-skinearlo al
+del mockup (nodos uniformes) sería un downgrade (se perdería el shape-coding informativo). Ya
+usa los tokens, así que hereda la paleta cálida automáticamente. → no se toca.
+
+**Epic 23 COMPLETO.** El badge de leyenda overlay (idea original de 23.4) se descartó: el
+tooltip al hover + el rail ya cubren "qué color es qué" sin duplicar con un overlay.
 
 **Notas para continuar:** todo el layout 2-col vive DENTRO de `ChoroplethMap.vue` (`.ws-map`/`.ws-rail`), porque el mapa+leyenda+result+ficha son un solo island con `transition:persist`. El badge (23.4) sería un overlay absolute sobre `.ws-map`. El timeline (23.6) toca `EleccionSelector.vue` (cuidado con la lógica de agrupado por año). El `<main>` se ensancha a `max-w-6xl` en `lg` (1024px), mismo breakpoint que el grid.

--- a/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
+++ b/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
@@ -74,3 +74,19 @@ Re-skin del `EleccionSelector` como línea de tiempo con nodos conectados + fade
 
 ## Secuencia
 Fase 1 = 23.1 · Fase 2 = 23.2 + 23.3 · Fase 3 = 23.4 + 23.5 (+ 23.6). Validar (`npm run check`, build, a11y) entre fases. Una rama por fase o PR incremental sobre `feat/epic-23-ux-redesign`.
+
+## Estado (2026-06-04)
+
+Rama `feat/epic-23-ux-redesign`. Todo verificado en browser (Playwright) + `npm run check` 0 errores.
+
+| Story | Estado | Commit |
+|---|---|---|
+| 23.1 base visual (tokens + `.seg`/`.card`/`.topbar`/`.num`, selectores segmented) | ✅ | `ddd5abf` |
+| 23.1 color (paleta exacta del mockup, dark cálido) | ✅ | `0db392a` |
+| 23.2 layout workspace 2-columnas (mapa + rail sticky) | ✅ | `11417c3` |
+| 23.5 dark mode toggle manual (claro/oscuro/auto, anti-flash) | ✅ | `e352df6` |
+| 23.3 rail de resultados como card | ✅ | `ff9a8be` |
+| 23.4 mapa: badge de leyenda overlay + tooltip on-brand (zoom ya existe) | ⏳ pendiente | |
+| 23.6 timeline con nodos conectados (re-skin EleccionSelector) | ⏳ pendiente | |
+
+**Notas para continuar:** todo el layout 2-col vive DENTRO de `ChoroplethMap.vue` (`.ws-map`/`.ws-rail`), porque el mapa+leyenda+result+ficha son un solo island con `transition:persist`. El badge (23.4) sería un overlay absolute sobre `.ws-map`. El timeline (23.6) toca `EleccionSelector.vue` (cuidado con la lógica de agrupado por año). El `<main>` se ensancha a `max-w-6xl` en `lg` (1024px), mismo breakpoint que el grid.

--- a/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
+++ b/docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md
@@ -1,0 +1,76 @@
+# Epic 23 — Rediseño UX "Atlas Electoral"
+
+_Arrancado 2026-06-04._
+
+Fuente: handoff de Claude Design (mockup HTML/React de alta fidelidad de la vista de departamento, con datos+geometría reales de Montevideo). El mockup explora 3 direcciones visuales; **se adopta solo la Dirección A · Editorial** (es la identidad actual de la app, pulida). Las direcciones B/C y el panel "Tweaks" son andamiaje de exploración y NO se portan.
+
+## Objetivo
+
+Subir el nivel de **layout y componentes** de la app sin perder funcionalidad, sacándole el "aura vibecodeada": jerarquía y ritmo profesionales, controles on-brand (segmented controls), resultados en cards, y un layout de dos columnas (mapa héroe + rail) en desktop que colapsa a una columna + bottom-sheet en mobile.
+
+**Principio rector (lección del chat de diseño):** el rediseño RE-SKINEA, no remueve. Toda función actual (filtro de listas por hoja —el corazón—, comparación, niveles, modos Ganador/Intensidad/Margen, búsqueda, export, ficha, plebiscitos, municipales, API) sigue intacta. La pega es visual y de layout, no de lógica.
+
+## No-goals
+
+- No tocar el modelo de datos, stores, ni la lógica de coloreo/agregación.
+- No portar las direcciones B/C ni el panel Tweaks.
+- No rehacer MapLibre/ChoroplethMap internamente (solo su chrome y overlays).
+
+## Decisiones del usuario (2026-06-04)
+
+- **Layout desktop:** 2 columnas (mapa + rail sticky). Mobile: 1 columna + bottom-sheet. ✅
+- **Implementación:** por fases, empezando por la base visual. ✅
+- **Dark mode:** toggle manual (claro/oscuro/auto) que persiste. ✅
+
+## Sistema visual (del mockup, Dirección A)
+
+Tokens ya casi idénticos a `src/styles/global.css`. Ajustes a incorporar (sin romper los actuales):
+- Escala de superficies/tinta/bordes refinada; `--accent` oxblood `#8A1C1C` se mantiene.
+- Tipografía: Source Serif 4 (display/números) + Inter (UI). `--num-feat` para tabular/lining.
+- Radios, sombras (sm/md/lg/sheet), densidad (`--pad`/`--gap`/`--rail-w`).
+- Componentes: `.topbar`, `.seg` (segmented), `.card`, `.winner-hero`, `.ranking`, `.map-frame`, `.map-badge`, `.map-zoom`, `.zone-panel`/`.zone-sheet`.
+
+---
+
+## Stories
+
+### 23.1 — Base visual (FASE 1) · _bajo riesgo, se ve en todas las vistas_
+Refinar el sistema de tokens y los componentes atómicos sin cambiar el layout todavía.
+**Alcance:** tokens (superficies, tipografía, radios, sombras, densidad) en `global.css`; topbar sticky con brand-mark; segmented controls reutilizables; estilo de cards; estilo de timeline refinado.
+**AC:**
+- Los tokens nuevos conviven con los existentes; ninguna vista actual se rompe (`npm run check` + build OK).
+- Existe una clase/comp `.seg` (segmented control) aplicable a LevelSelector/GranularitySelector/modos.
+- Topbar sticky con marca; el masthead actual migra a ella.
+- Dark sigue funcionando (auto, hasta 23.5).
+- Sin regresiones de a11y (focus-visible, contraste) ni de los gates.
+
+### 23.2 — Layout workspace 2-columnas (FASE 2)
+Vista de departamento y nacional: grid `1fr var(--rail-w)` en desktop; 1 columna + bottom-sheet en mobile (`@media max-width:940px`).
+**AC:**
+- Desktop ≥940px: mapa a la izq (héroe), rail sticky a la der. Mobile: 1 columna; la ficha de zona es bottom-sheet.
+- `transition:persist` del mapa sigue vivo entre navegaciones (NFR1).
+- Controles del mapa (timeline, niveles, modos, listas) reubicados arriba del mapa, coherentes en ambos breakpoints.
+
+### 23.3 — Rail de resultados (FASE 2)
+Portar `ResultadoGlobal` → card winner-hero (bandera + nombre serif + % grande) + ranking territorial (barras + zonas ganadas). Ficha de zona como card en el rail (desktop) / sheet (mobile).
+**AC:**
+- Winner-hero muestra ganador, %, y meta. Ranking lista opciones con barra y nº de zonas ganadas.
+- Reusa los datos/stores actuales; sin recálculo nuevo.
+- En plebiscitos/municipales degrada coherente (Sí/No; alcalde/lema).
+
+### 23.4 — Mapa pulido (FASE 3)
+`map-frame` con borde/sombra; `map-badge` (leyenda-chip abajo-izq); zoom abajo-der; tooltip on-brand. Sin tocar la lógica de capas.
+**AC:** badge refleja el modo actual; zoom +/- funciona; tooltip muestra nombre+ganador; nada rompe el overlay de puntos (local/circuito).
+
+### 23.5 — Dark mode toggle (FASE 3)
+Botón en la topbar: claro / oscuro / auto, persistido en `localStorage`. `data-theme` en el root; default = auto (`prefers-color-scheme`).
+**AC:** el toggle cambia el tema sin recarga, persiste, y respeta `auto`. SSR-safe (sin flash).
+
+### 23.6 — Timeline refinado (FASE 3, opcional)
+Re-skin del `EleccionSelector` como línea de tiempo con nodos conectados + fades, manteniendo el orden cronológico y el agrupado actual.
+**AC:** mismas elecciones/orden; activo destacado; scrollable con fades; sin cambiar la navegación.
+
+---
+
+## Secuencia
+Fase 1 = 23.1 · Fase 2 = 23.2 + 23.3 · Fase 3 = 23.4 + 23.5 (+ 23.6). Validar (`npm run check`, build, a11y) entre fases. Una rama por fase o PR incremental sobre `feat/epic-23-ux-redesign`.

--- a/public/flags/cr.svg
+++ b/public/flags/cr.svg
@@ -1,7 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 60">
-  <!-- Coalición Republicana: blanco con barras roja+azul y estrella amarilla, emblema CENTRADO -->
-  <rect x="0" y="0" width="90" height="60" fill="#FFFFFF"/>
-  <rect x="36" y="20" width="9" height="32" fill="#FD0000"/>
-  <rect x="45" y="20" width="9" height="32" fill="#000163"/>
-  <path fill="#FFD400" d="M50 5 L51.65 9.74 L56.66 9.84 L52.66 12.87 L54.11 17.66 L50 14.8 L45.89 17.66 L47.34 12.87 L43.34 9.84 L48.35 9.74 Z"/>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 1000" width="1500" height="1000">
+  <!-- Coalición Republicana — Bandera Multicolor (fuente: Wikimedia "Bandera Coalición Multicolor.svg").
+       Franjas: celeste / rojo / amarillo / verde / violeta. Anterior en docs/flags-backup/cr-clasica.svg. -->
+  <style>
+    .s0 { fill: #80bfff }
+    .s1 { fill: #bb0000 }
+    .s2 { fill: #f7bb1f }
+    .s3 { fill: #79bb59 }
+    .s4 { fill: #640999 }
+  </style>
+  <path class="s0" d="m0 0h1500v1000h-1500z"/>
+  <path class="s1" d="m0 200h1500v800h-1500z"/>
+  <path class="s2" d="m0 400h1500v600h-1500z"/>
+  <path class="s3" d="m0 600h1500v400h-1500z"/>
+  <path class="s4" d="m0 800h1500v200h-1500z"/>
 </svg>

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2801,17 +2801,22 @@ onUnmounted(() => {
 .map-status--error {
   color: #b91c1c;
 }
+/* Segmented controls dentro del mapa (Epic 23): modo de vista/coloreo on-brand
+   (antes botones unidos con azul #1d4ed8). Track + píldora, igual que el .seg global. */
 .vista-toggle {
   display: flex;
-  gap: 0;
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid var(--color-border);
+  gap: 2px;
+  margin: 0.5rem 0.75rem;
+  padding: 3px;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
 }
 /* Cluster de coloreo (Epic 19.1): UN solo borde superior para todo el bloque de controles.
    Dentro del cluster el toggle pierde su borde propio (lo aporta el cluster) y el selector de
    nivel se pega como sub-fila, evitando dos bandas pares apiladas. */
 .coloreo-cluster { border-top: 1px solid var(--color-border); }
-.coloreo-cluster .vista-toggle { border-top: none; padding-bottom: 0.375rem; }
+.coloreo-cluster .vista-toggle { margin-top: 0.5rem; margin-bottom: 0.375rem; }
 /* Selector de nivel del ganador (coloreo-por-nivel). Por defecto (vista base, va solo) = fila normal. */
 .gnivel { display: flex; flex-wrap: wrap; align-items: center; gap: 0.375rem; padding: 0.375rem 0.75rem 0.5rem; font-size: 0.75rem; }
 /* Cuando sigue al toggle (selección + modo Ganador) se muestra como sub-fila tenue e indentada de él. */
@@ -2822,26 +2827,24 @@ onUnmounted(() => {
 .gnivel__btn:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
 .vista-toggle__btn {
   flex: 1;
-  padding: 0.375rem 0.5rem;
+  padding: 0.4rem 0.5rem;
   font-size: 0.8125rem;
-  background: var(--color-surface-1);
-  border: 1px solid var(--color-border-strong);
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
   cursor: pointer;
-  color: var(--color-ink-soft);
-  min-height: 44px;
+  color: var(--color-ink-muted);
+  min-height: 34px;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
 }
-.vista-toggle__btn:first-child {
-  border-radius: 0.25rem 0 0 0.25rem;
-}
-.vista-toggle__btn:last-child {
-  border-radius: 0 0.25rem 0.25rem 0;
-  border-left: none;
-}
+.vista-toggle__btn:hover { color: var(--color-ink); }
+.vista-toggle__btn:focus-visible { outline: 2px solid var(--color-focus); outline-offset: -2px; }
 .vista-toggle__btn--activo {
-  background: #1d4ed8;
-  color: #fff;
+  background: var(--color-card);
+  color: var(--color-ink);
   font-weight: 700;
-  border-color: #1d4ed8;
+  box-shadow: var(--shadow-sm);
 }
 
 /* Comparación Fase 2: controles de "cómo ver el contraste", debajo del mapa (no re-satura arriba). */
@@ -2852,20 +2855,28 @@ onUnmounted(() => {
   padding: 0.5rem 0.75rem;
   border-top: 1px solid var(--color-border);
 }
-.cmp-view__modos { display: flex; gap: 0; }
+.cmp-view__modos {
+  display: flex; gap: 2px; padding: 3px;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
 .cmp-view__btn {
   flex: 1;
-  padding: 0.35rem 0.5rem;
+  padding: 0.4rem 0.5rem;
   font-size: 0.75rem;
-  background: var(--color-surface-1);
-  border: 1px solid var(--color-border-strong);
-  color: var(--color-ink-soft);
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  color: var(--color-ink-muted);
   cursor: pointer;
-  min-height: 36px;
+  min-height: 32px;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
 }
-.cmp-view__btn:first-child { border-radius: 0.25rem 0 0 0.25rem; }
-.cmp-view__btn:last-child { border-radius: 0 0.25rem 0.25rem 0; border-left: none; }
-.cmp-view__btn--activo { background: #1d4ed8; color: #fff; font-weight: 700; border-color: #1d4ed8; }
+.cmp-view__btn:hover { color: var(--color-ink); }
+.cmp-view__btn:focus-visible { outline: 2px solid var(--color-focus); outline-offset: -2px; }
+.cmp-view__btn--activo { background: var(--color-card); color: var(--color-ink); font-weight: 700; box-shadow: var(--shadow-sm); }
 .cmp-view__delta { display: flex; flex-direction: column; gap: 0.375rem; }
 .cmp-view__lbl { font-size: 0.75rem; color: var(--color-ink-soft); display: flex; align-items: center; gap: 0.375rem; }
 .cmp-view__sel {

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2762,30 +2762,21 @@ onUnmounted(() => {
 </style>
 
 <style scoped>
+/* Epic 23: layout single-column map-first (se revirtió el grid 2-columnas: dejaba un
+   rectángulo vacío grande junto al result card y enterraba el mapa). El orden natural
+   queda map → controles (ws-map) → ficha + resultado (ws-rail), como la UI previa pero
+   con las cards/segmented/paleta nuevas. */
 .map-wrap {
   display: flex;
   flex-direction: column;
 }
 .ws-map { min-width: 0; display: flex; flex-direction: column; }
-
-/* Epic 23 · Story 23.2 — workspace 2 columnas en desktop: mapa (héroe) + rail sticky.
-   Breakpoint alineado con Tailwind lg (el <main> se ensancha a max-w-6xl ahí).
-   En mobile (<1024px) cae a 1 columna (flex column del .map-wrap). */
-@media (min-width: 1024px) {
-  .map-wrap {
-    display: grid;
-    grid-template-columns: 1fr var(--rail-w);
-    gap: var(--gap);
-    align-items: start;
-  }
-  .ws-rail {
-    position: sticky;
-    top: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    min-width: 0;
-  }
+.ws-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  min-width: 0;
+  margin-top: 0.625rem;
 }
 .map {
   width: 100%;

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2674,6 +2674,38 @@ onUnmounted(() => {
 <style>
 @import 'maplibre-gl/dist/maplibre-gl.css';
 
+/* Epic 23 · Story 23.4 — control de zoom on-brand (la card blanca default desentona con
+   el papel cálido y el dark). Sin tocar la lógica: solo re-skin del NavigationControl. */
+.maplibregl-ctrl-group {
+  background: color-mix(in srgb, var(--color-card) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.maplibregl-ctrl-group button {
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  color: var(--color-ink-soft);
+}
+.maplibregl-ctrl-group button + button {
+  border-top: 1px solid var(--color-border);
+}
+.maplibregl-ctrl-group button:hover {
+  background: var(--color-surface-2);
+}
+.maplibregl-ctrl-group button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: -2px;
+}
+/* los íconos +/- de maplibre son background-image (SVG con stroke fijo); en dark se invierten
+   para que se vean sobre el control oscuro. */
+:root[data-theme="dark"] .maplibregl-ctrl-group button .maplibregl-ctrl-icon {
+  filter: invert(1) brightness(1.6);
+}
+
 .zona-sigla {
   font: 700 0.6875rem/1 system-ui, sans-serif;
   color: var(--color-ink);

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2462,8 +2462,32 @@ onMounted(async () => {
         if (!f) return;
         commit({ zona: String((f.properties as { name: string }).name) });
       });
-      m.on('mouseenter', 'zonas-fill', () => { m.getCanvas().style.cursor = 'pointer'; });
-      m.on('mouseleave', 'zonas-fill', () => { m.getCanvas().style.cursor = ''; });
+      // Tooltip on-brand al hover (Epic 23 · Story 23.4): nombre de la zona + ganador base.
+      // Lee zonasVotos/zonasValidos (geoId normalizado); si no hay dato, muestra solo el nombre.
+      const hoverTip = mlLib ? new mlLib.Popup({ closeButton: false, closeOnClick: false, offset: 12, className: 'map-tip-pop' }) : null;
+      const tipHTML = (name: string): string => {
+        const key = norm(name);
+        const votos = zonasVotos.get(key);
+        const validos = zonasValidos.get(key) ?? 0;
+        let row = '';
+        if (votos && votos.size > 0 && validos > 0) {
+          let bestId = ''; let best = -1;
+          for (const [id, v] of votos) if (v > best) { best = v; bestId = id; }
+          if (bestId) {
+            const meta = resolveParty(opcNombreMap.get(bestId) ?? bestId, activeEleccion);
+            const pct = (best / validos * 100).toFixed(1);
+            row = `<div class="tt-row"><span class="tt-sw" style="background:${meta.color}"></span>${meta.sigla} · ${pct}%</div>`;
+          }
+        }
+        return `<div class="tt-name">${name}</div>${row}`;
+      };
+      m.on('mousemove', 'zonas-fill', (e) => {
+        const f = e.features?.[0];
+        if (!f || !hoverTip) return;
+        m.getCanvas().style.cursor = 'pointer';
+        hoverTip.setLngLat(e.lngLat).setHTML(tipHTML(String((f.properties as { name: string }).name))).addTo(m);
+      });
+      m.on('mouseleave', 'zonas-fill', () => { m.getCanvas().style.cursor = ''; hoverTip?.remove(); });
 
       m.on('click', 'zonas-circle', (e) => {
         const f = e.features?.[0];
@@ -2705,6 +2729,25 @@ onUnmounted(() => {
 :root[data-theme="dark"] .maplibregl-ctrl-group button .maplibregl-ctrl-icon {
   filter: invert(1) brightness(1.6);
 }
+
+/* Tooltip al hover (Story 23.4): tinta sobre fondo claro/oscuro, sin la flecha default. */
+.map-tip-pop { pointer-events: none; }
+.map-tip-pop .maplibregl-popup-content {
+  background: var(--color-ink);
+  color: var(--color-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 7px 10px;
+  font-family: var(--font-ui);
+}
+.map-tip-pop .maplibregl-popup-tip { display: none; }
+.map-tip-pop .tt-name { font-weight: 700; font-size: 12.5px; line-height: 1.2; }
+.map-tip-pop .tt-row {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11.5px; margin-top: 3px; opacity: 0.92;
+  font-variant-numeric: tabular-nums;
+}
+.map-tip-pop .tt-sw { width: 8px; height: 8px; border-radius: 2px; display: inline-block; flex: none; }
 
 .zona-sigla {
   font: 700 0.6875rem/1 system-ui, sans-serif;

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -2554,6 +2554,9 @@ onUnmounted(() => {
 
 <template>
   <section class="map-wrap" aria-label="Mapa electoral por zona">
+   <!-- Columna del mapa (héroe). En desktop ≥940px queda a la izquierda; el rail de
+        resultados va a la derecha (Epic 23 · Story 23.2). -->
+   <div class="ws-map">
     <div ref="mapEl" class="map" role="img" :aria-label="`Mapa de ${departamento}, ${eleccion}, coloreado por partido ganador`"></div>
 
     <p v-if="status === 'cargando'" class="map-status">Cargando mapa…</p>
@@ -2644,10 +2647,14 @@ onUnmounted(() => {
       </div>
     </div>
 
+   </div><!-- /.ws-map -->
+
+   <!-- Rail de resultados (Epic 23 · Story 23.2/23.3): en desktop ≥940px columna sticky a la
+        derecha; en mobile cae debajo del mapa en una sola columna. -->
+   <aside class="ws-rail">
     <!-- Ficha de zona (detalle on-demand al clickear un polígono): va ARRIBA del RESULTADO
          agregado. Cuando no hay zona seleccionada colapsa a max-height:0 (no ocupa espacio),
-         así el resultado nacional/depto queda pegado a los controles; al clickear, el detalle
-         dinámico de la zona aparece por ENCIMA del resultado agregado. -->
+         al clickear, el detalle dinámico de la zona aparece por ENCIMA del resultado agregado. -->
     <ZoneSheet
       :sel="selected"
       :opcion-sigla="opcionActiva ? (opcNombreMap.get(opcionActiva) ? resolveParty(opcNombreMap.get(opcionActiva)!).sigla : opcionActiva) : null"
@@ -2660,6 +2667,7 @@ onUnmounted(() => {
       :titulo="departamento === '_nacional' ? 'Resultado nacional' : 'Resultado'"
       :contexto="resultadoCtx"
     />
+   </aside><!-- /.ws-rail -->
   </section>
 </template>
 
@@ -2682,6 +2690,27 @@ onUnmounted(() => {
 .map-wrap {
   display: flex;
   flex-direction: column;
+}
+.ws-map { min-width: 0; display: flex; flex-direction: column; }
+
+/* Epic 23 · Story 23.2 — workspace 2 columnas en desktop: mapa (héroe) + rail sticky.
+   Breakpoint alineado con Tailwind lg (el <main> se ensancha a max-w-6xl ahí).
+   En mobile (<1024px) cae a 1 columna (flex column del .map-wrap). */
+@media (min-width: 1024px) {
+  .map-wrap {
+    display: grid;
+    grid-template-columns: 1fr var(--rail-w);
+    gap: var(--gap);
+    align-items: start;
+  }
+  .ws-rail {
+    position: sticky;
+    top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 0;
+  }
 }
 .map {
   width: 100%;

--- a/src/components/map/ChoroplethMap.vue
+++ b/src/components/map/ChoroplethMap.vue
@@ -49,6 +49,8 @@ interface SelInfo {
   geoId: string;
   /** Etiqueta de display: "Localidad · SERIE" en nivel serie, undefined en otros niveles. */
   label?: string;
+  /** Nombre del nivel geográfico de la ficha (Barrio / Localidad / Departamento / Municipio / …). */
+  nivelLabel?: string;
   sigla: string;
   nombre: string;
   color: string;
@@ -169,6 +171,21 @@ let activeEleccion = props.eleccion;
 let activeDepartamento = props.departamento;
 // Nivel activo en curso (sincronizado con URL/$level tras resolución de DEPT_AVAIL).
 let activeNivel: NivelGeografico = 'zona';
+
+/** Nombre del nivel geográfico de la ficha, según lo que se está viendo (Barrio / Localidad /
+ *  Departamento / Municipio / Serie / Circuito / Local). 'zona' en Montevideo = "Barrio". */
+function nivelLabelActual(): string {
+  const n = activeNivel;
+  if (n === 'departamento') return 'Departamento';
+  if (n === 'municipio') return 'Municipio';
+  if (n === 'barrio') return 'Barrio';
+  if (n === 'localidad') return 'Localidad';
+  if (n === 'serie') return 'Serie';
+  if (n === 'circuito') return 'Circuito';
+  if (n === 'local') return 'Local';
+  // 'zona' (base genérico): en Montevideo son barrios.
+  return activeDepartamento === 'montevideo' ? 'Barrio' : 'Zona';
+}
 // Unsub de $level para limpiar en onUnmounted.
 let unsubLevel: (() => void) | null = null;
 // Catálogo opcionId→nombre y snapshot de leyenda en modo ganador (Story 2.2).
@@ -2177,6 +2194,7 @@ function selectByName(name: string, fc: FeatureCollection): void {
     selected.value = {
       geoId: rawGeoId,
       label: zonaNombre ? `${zonaNombre} · ${rawGeoId.toUpperCase()}` : undefined,
+      nivelLabel: nivelLabelActual(),
       sigla: String(p.sigla),
       nombre: String(p.nombre),
       color: String(p.color),
@@ -2205,6 +2223,7 @@ function selectByName(name: string, fc: FeatureCollection): void {
     selected.value = {
       geoId: rawGeoId2,
       label: zonaNombre2 ? `${zonaNombre2} · ${rawGeoId2.toUpperCase()}` : undefined,
+      nivelLabel: nivelLabelActual(),
       sigla: '', nombre: 'Sin datos', color: '#e5e7eb',
       votoGanador: 0, validos: 0, pct: 0, enBlanco: 0, anulados: 0, observados: 0,
       pctOpcionActiva: null,
@@ -2242,6 +2261,7 @@ function selectCircuitoLocal(name: string): void {
   selected.value = {
     geoId: name,
     label: z.local?.nombre ?? name,
+    nivelLabel: z.local ? 'Local' : 'Circuito',
     sigla: ganMeta.sigla, nombre: ganNombre, color: ganMeta.color, flagUrl: ganMeta.flagUrl,
     votoGanador, validos: z.validos,
     pct: z.validos > 0 ? (votoGanador / z.validos) * 100 : 0,
@@ -2587,10 +2607,12 @@ onUnmounted(() => {
     <p v-else-if="status === 'error'" class="map-status map-status--error">Error: {{ errorMsg }}</p>
 
     <!-- Leyenda: explica los colores del mapa → va PEGADA al mapa, arriba del toggle de
-         coloreo y del RESULTADO. Solo aporta en modos selección/filtro/intensidad (escala)
-         o si hay nota de votos sin ubicación; en el modo ganador base duplica a RESULTADO. -->
+         coloreo y del RESULTADO. Aporta en modos selección/filtro/intensidad (escala), si hay
+         nota de votos sin ubicación, o en la VISTA NACIONAL (mapa multi-partido por depto, donde
+         la leyenda de colores es necesaria —pedido del usuario). En depto modo ganador base se
+         omite porque duplica al RESULTADO. -->
     <MapLegend
-      v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema' || comparacionActiva"
+      v-if="opcionActiva || seleccionActiva.length > 0 || votosSinUbicacion > 0 || gnivel !== 'lema' || comparacionActiva || (departamento === '_nacional' && legend.length > 0)"
       :entradas="legend" :sin-datos="sinDatos" :votos-sin-ubicacion="votosSinUbicacion" :zonas-sin-ubicacion="zonasSinUbicacion"
       :comparacion-nota="comparacionActiva && cmpModo === 'ganador' ? 'Zonas a todo color: cambió el partido ganador entre las dos elecciones. Las atenuadas mantuvieron el mismo ganador.' : null" />
 

--- a/src/components/map/ResultadoGlobal.vue
+++ b/src/components/map/ResultadoGlobal.vue
@@ -100,13 +100,10 @@ const resumen = computed(() =>
 </template>
 
 <style scoped>
-/* Epic 23 · Story 23.3 — card del rail (antes era border-top para el layout apilado). */
 .resultado {
   background: var(--color-card);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  padding: 0.875rem 1rem 1rem;
+  border-top: 1px solid var(--color-border);
+  padding: 0.75rem 1rem;
 }
 .resultado__toggle {
   display: flex;

--- a/src/components/map/ResultadoGlobal.vue
+++ b/src/components/map/ResultadoGlobal.vue
@@ -100,10 +100,13 @@ const resumen = computed(() =>
 </template>
 
 <style scoped>
+/* Epic 23 · Story 23.3 — card del rail (antes era border-top para el layout apilado). */
 .resultado {
   background: var(--color-card);
-  border-top: 1px solid var(--color-border);
-  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 0.875rem 1rem 1rem;
 }
 .resultado__toggle {
   display: flex;

--- a/src/components/selectors/GranularitySelector.vue
+++ b/src/components/selectors/GranularitySelector.vue
@@ -27,21 +27,21 @@ function selectZona() {
 </script>
 
 <template>
-  <div class="gran-sel" role="group" aria-label="Granularidad del mapa nacional">
-    <button
-      class="gran-sel__btn"
-      :class="{ 'gran-sel__btn--activo': !isZona }"
-      type="button"
-      :aria-pressed="!isZona"
-      @click="selectDepto"
-    >Departamentos</button>
-    <button
-      class="gran-sel__btn"
-      :class="{ 'gran-sel__btn--activo': isZona }"
-      type="button"
-      :aria-pressed="isZona"
-      @click="selectZona"
-    >Zonas</button>
+  <div class="gran-sel">
+    <div class="seg" role="group" aria-label="Granularidad del mapa nacional">
+      <button
+        :class="{ on: !isZona }"
+        type="button"
+        :aria-pressed="!isZona"
+        @click="selectDepto"
+      >Departamentos</button>
+      <button
+        :class="{ on: isZona }"
+        type="button"
+        :aria-pressed="isZona"
+        @click="selectZona"
+      >Zonas</button>
+    </div>
   </div>
 </template>
 
@@ -49,26 +49,6 @@ function selectZona() {
 .gran-sel {
   display: flex;
   justify-content: center;
-  gap: 0;
   padding: 0.5rem 0 0.75rem;
 }
-.gran-sel__btn {
-  font: inherit;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  padding: 0.4rem 1.1rem;
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-paper);
-  color: var(--color-ink-muted);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-.gran-sel__btn:first-child { border-radius: 6px 0 0 6px; border-right: none; }
-.gran-sel__btn:last-child  { border-radius: 0 6px 6px 0; }
-.gran-sel__btn--activo {
-  background: var(--color-ink);
-  color: var(--color-paper);
-  border-color: var(--color-ink);
-}
-.gran-sel__btn:not(.gran-sel__btn--activo):hover { color: var(--color-ink); }
 </style>

--- a/src/components/selectors/LevelSelector.vue
+++ b/src/components/selectors/LevelSelector.vue
@@ -32,7 +32,8 @@ const BASE_LABELS: Partial<Record<NivelGeografico, string>> = {
 const baseLabel = computed(() => BASE_LABELS[defaultBase.value] ?? 'Zonas');
 
 function selectBase() {
-  commit({ level: defaultBase.value, zona: null });
+  // Volver a la vista base apaga el overlay de circuito (toggle de 2 vías).
+  commit({ level: defaultBase.value, zona: null, circ: false });
 }
 
 function toggleCircuito() {
@@ -43,86 +44,39 @@ function toggleCircuito() {
 </script>
 
 <template>
-  <div class="level-sel" role="group" aria-label="Nivel geográfico">
-    <button
-      class="level-sel__btn level-sel__btn--activo"
-      type="button"
-      aria-pressed="true"
-      @click="selectBase"
-    >{{ baseLabel }}</button>
+  <div class="level-sel">
+    <div class="seg" role="group" aria-label="Nivel geográfico">
+      <button
+        :class="{ on: !isCircuito }"
+        type="button"
+        :aria-pressed="!isCircuito"
+        @click="selectBase"
+      >{{ baseLabel }}</button>
 
-    <button
-      class="level-sel__btn level-sel__btn--circuito"
-      :class="{ 'level-sel__btn--activo': isCircuito, 'level-sel__btn--disabled': !hasCircuito }"
-      type="button"
-      :aria-pressed="isCircuito"
-      :aria-disabled="!hasCircuito"
-      @click="toggleCircuito"
-    >
-      <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true" style="flex-shrink:0">
-        <rect x="0.5" y="0.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
-        <rect x="7.5" y="0.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
-        <rect x="0.5" y="7.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
-        <rect x="7.5" y="7.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
-      </svg>
-      Circuito
-    </button>
+      <button
+        :class="{ on: isCircuito }"
+        type="button"
+        :aria-pressed="isCircuito"
+        :aria-disabled="!hasCircuito"
+        :disabled="!hasCircuito"
+        @click="toggleCircuito"
+      >
+        <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+          <rect x="0.5" y="0.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
+          <rect x="7.5" y="0.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
+          <rect x="0.5" y="7.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
+          <rect x="7.5" y="7.5" width="5" height="5" rx="0.5" stroke="currentColor"/>
+        </svg>
+        Circuito
+      </button>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .level-sel {
   display: flex;
-  align-items: center;
   justify-content: center;
-  gap: 0.375rem;
   padding: 0.5rem 1rem;
-  font-size: 0.8125rem;
-}
-
-.level-sel__btn {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.3125rem 0.75rem;
-  border: 1px solid var(--color-border-strong);
-  border-radius: 0.375rem;
-  background: var(--color-card);
-  font-size: 0.8125rem;
-  cursor: pointer;
-  color: var(--color-ink-soft);
-  min-height: 32px;
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
-  white-space: nowrap;
-}
-.level-sel__btn:hover {
-  background: var(--color-surface-2);
-  border-color: var(--color-ink-faint);
-}
-.level-sel__btn--activo {
-  background: var(--color-btn-active-bg);
-  color: var(--color-btn-active-fg);
-  border-color: var(--color-btn-active-bg);
-  font-weight: 700;
-}
-.level-sel__btn--activo:hover {
-  background: var(--color-btn-active-bg);
-}
-
-/* Circuito — visualmente separado, tipo toggle */
-.level-sel__btn--circuito {
-  margin-left: 0.5rem;
-  border-style: dashed;
-  color: var(--color-ink-muted);
-}
-.level-sel__btn--circuito.level-sel__btn--activo {
-  border-style: solid;
-  background: var(--color-btn-active-bg);
-  color: var(--color-btn-active-fg);
-}
-.level-sel__btn--disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-  pointer-events: none;
 }
 </style>

--- a/src/components/selectors/OpcionAccordion.vue
+++ b/src/components/selectors/OpcionAccordion.vue
@@ -383,294 +383,435 @@ const flagLema  = (l: NodoOpcion): string | null => resolveParty(l.etiqueta).fla
     </button>
 
     <div v-show="panelOpen || !contienda" class="acc__body">
-    <!-- Selector de contienda (solo si hay >1) -->
-    <div v-if="tieneVariasContiendas" class="acc__contiendas" role="tablist" aria-label="Contienda">
-      <button
-        v-for="c in catalogo?.contiendas"
-        :key="c.contienda"
-        type="button"
-        role="tab"
-        :aria-selected="c.contienda === contiendaActiva"
-        class="acc__contienda"
-        :class="{ 'acc__contienda--activa': c.contienda === contiendaActiva }"
-        @click="cambiarContienda(c.contienda)"
-      >
-        {{ CONTIENDA_LABEL[c.contienda] ?? c.contienda }}
-      </button>
-    </div>
 
-    <!-- Filtro + búsqueda + acciones -->
-    <div v-if="contienda && !esPlano" class="acc__controles">
-      <input
-        v-model="busqueda"
-        class="acc__busqueda"
-        type="search"
-        :inputmode="nivelHoja === 'candidato' ? 'text' : 'numeric'"
-        :placeholder="nivelHoja === 'candidato' ? 'Buscar candidato…' : 'Buscar lista por número…'"
-        :aria-label="nivelHoja === 'candidato' ? 'Buscar candidato' : 'Buscar lista por número'"
-      />
-      <select v-model="filtroPartido" class="acc__filtro" aria-label="Filtrar por partido">
-        <option value="">Todos los partidos</option>
-        <option v-for="p in partidos" :key="p.id" :value="p.id">{{ p.nombre }}</option>
-      </select>
-    </div>
+      <!-- Tabs de contienda (solo si hay >1) -->
+      <div v-if="tieneVariasContiendas" class="acc__contiendas" role="tablist" aria-label="Contienda">
+        <button
+          v-for="c in catalogo?.contiendas"
+          :key="c.contienda"
+          type="button"
+          role="tab"
+          :aria-selected="c.contienda === contiendaActiva"
+          class="acc__contienda"
+          :class="{ 'acc__contienda--activa': c.contienda === contiendaActiva }"
+          @click="cambiarContienda(c.contienda)"
+        >
+          {{ CONTIENDA_LABEL[c.contienda] ?? c.contienda }}
+        </button>
+      </div>
 
-    <!-- Acciones: botones claros (antes eran links de texto poco visibles) -->
-    <div v-if="contienda && !esPlano" class="acc__acciones">
-      <button class="acc__btn" type="button" @click="seleccionarTodasVisibles">
-        <span aria-hidden="true">☑</span> Seleccionar todas
-      </button>
-      <button class="acc__btn acc__btn--ghost" type="button" :disabled="seleccion.size === 0" @click="limpiarTodo">
-        <span aria-hidden="true">✕</span> Limpiar<span v-if="seleccion.size"> ({{ seleccion.size }})</span>
-      </button>
-    </div>
+      <!-- Búsqueda + filtro de partido -->
+      <div v-if="contienda && !esPlano" class="acc__controles">
+        <input
+          v-model="busqueda"
+          class="acc__busqueda"
+          type="search"
+          :inputmode="nivelHoja === 'candidato' ? 'text' : 'numeric'"
+          :placeholder="nivelHoja === 'candidato' ? 'Buscar candidato…' : 'Buscar lista por número…'"
+          :aria-label="nivelHoja === 'candidato' ? 'Buscar candidato' : 'Buscar lista por número'"
+        />
+        <select v-model="filtroPartido" class="acc__filtro" aria-label="Filtrar por partido">
+          <option value="">Todos los partidos</option>
+          <option v-for="p in partidos" :key="p.id" :value="p.id">{{ p.nombre }}</option>
+        </select>
+      </div>
 
-    <!-- Chips de filtros/selección activos -->
-    <div v-if="seleccion.size > 0 || filtroPartido || busqueda" class="acc__chips" aria-live="polite">
-      <span v-if="filtroPartido" class="acc__chip">
-        {{ partidos.find((p) => p.id === filtroPartido)?.nombre }}
-        <button type="button" aria-label="Quitar filtro de partido" @click="filtroPartido = ''">✕</button>
-      </span>
-      <span v-if="busqueda" class="acc__chip">
-        "{{ busqueda }}"
-        <button type="button" aria-label="Limpiar búsqueda" @click="busqueda = ''">✕</button>
-      </span>
-      <span v-if="seleccion.size > 0" class="acc__chip acc__chip--sel">
-        {{ seleccion.size }} {{ seleccion.size === 1 ? 'lista' : 'listas' }} seleccionada{{ seleccion.size === 1 ? '' : 's' }}
-      </span>
-    </div>
+      <!-- Chips de filtros/selección activos -->
+      <div v-if="seleccion.size > 0 || filtroPartido || busqueda" class="acc__chips" aria-live="polite">
+        <span v-if="filtroPartido" class="acc__chip">
+          {{ partidos.find((p) => p.id === filtroPartido)?.nombre }}
+          <button type="button" aria-label="Quitar filtro de partido" @click="filtroPartido = ''">✕</button>
+        </span>
+        <span v-if="busqueda" class="acc__chip">
+          "{{ busqueda }}"
+          <button type="button" aria-label="Limpiar búsqueda" @click="busqueda = ''">✕</button>
+        </span>
+        <span v-if="seleccion.size > 0" class="acc__chip acc__chip--sel">
+          {{ seleccion.size }} {{ seleccion.size === 1 ? 'lista' : 'listas' }} seleccionada{{ seleccion.size === 1 ? '' : 's' }}
+        </span>
+      </div>
 
-    <!-- Rótulo de degradación: escalera sin nivel sublema por falta de dato (AC2, Story 10.7) -->
-    <p v-if="contienda?.degradado" class="acc__degradado">
-      Sin desglose por sublema — dato no disponible; se muestra lema → lista.
-    </p>
+      <!-- Rótulo de degradación: escalera sin nivel sublema por falta de dato (AC2, Story 10.7) -->
+      <p v-if="contienda?.degradado" class="acc__degradado">
+        Sin desglose por sublema — dato no disponible; se muestra lema → lista.
+      </p>
 
-    <!-- Árbol -->
-    <ul v-if="contienda && !esPlano" class="acc__tree" role="tree">
-      <li v-for="l in lemas" :key="l.id" class="acc__lema" role="treeitem" :aria-expanded="expandidos.has(l.id)">
-        <div class="acc__row acc__row--lema">
-          <button
-            type="button"
-            class="acc__cb"
-            :class="`acc__cb--${tri(hojasDeLema(l.id))}`"
-            :aria-label="`Seleccionar todas las listas de ${l.etiqueta}`"
-            @click="toggleSet(hojasDeLema(l.id))"
-          ><span aria-hidden="true">{{ tri(hojasDeLema(l.id)) === 'full' ? '✓' : tri(hojasDeLema(l.id)) === 'partial' ? '–' : '' }}</span></button>
-          <button
-            type="button"
-            class="acc__expand"
-            :aria-expanded="expandidos.has(l.id)"
-            :aria-label="`${expandidos.has(l.id) ? 'Contraer' : 'Ver listas de'} ${l.etiqueta}`"
-            @click="toggleExpand(l.id)"
-          >
-            <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(l.id) ? '▾' : '▸' }}</span>
-            <img v-if="flagLema(l)" :src="flagLema(l)!" :alt="siglaLema(l)" class="acc__flag" aria-hidden="true" />
-            <span v-else class="acc__swatch" :style="{ background: colorLema(l) }" aria-hidden="true"></span>
-            <span class="acc__sigla">{{ siglaLema(l) }}</span>
-            <span class="acc__etiqueta">{{ l.etiqueta }}</span>
-          </button>
-        </div>
+      <!-- Árbol jerárquico -->
+      <ul v-if="contienda && !esPlano" class="acc__tree" role="tree">
+        <li v-for="l in lemas" :key="l.id" class="acc__lema" role="treeitem" :aria-expanded="expandidos.has(l.id)">
+          <div class="acc__row acc__row--lema">
+            <button
+              type="button"
+              class="acc__cb"
+              :class="`acc__cb--${tri(hojasDeLema(l.id))}`"
+              :aria-label="`Seleccionar todas las listas de ${l.etiqueta}`"
+              @click="toggleSet(hojasDeLema(l.id))"
+            ><span aria-hidden="true">{{ tri(hojasDeLema(l.id)) === 'full' ? '✓' : tri(hojasDeLema(l.id)) === 'partial' ? '–' : '' }}</span></button>
+            <button
+              type="button"
+              class="acc__expand"
+              :aria-expanded="expandidos.has(l.id)"
+              :aria-label="`${expandidos.has(l.id) ? 'Contraer' : 'Ver listas de'} ${l.etiqueta}`"
+              @click="toggleExpand(l.id)"
+            >
+              <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(l.id) ? '▾' : '▸' }}</span>
+              <img v-if="flagLema(l)" :src="flagLema(l)!" :alt="siglaLema(l)" class="acc__flag" aria-hidden="true" />
+              <span v-else class="acc__swatch" :style="{ background: colorLema(l) }" aria-hidden="true"></span>
+              <span class="acc__sigla">{{ siglaLema(l) }}</span>
+              <span class="acc__etiqueta">{{ l.etiqueta }}</span>
+            </button>
+          </div>
 
-        <ul v-if="expandidos.has(l.id)" class="acc__children" role="group">
-          <!-- Nivel intermedio 1 (precandidato en ODN; sublema en ODD/nacionales): lema → g1 -->
-          <li v-for="g in gruposDe(l.id)" :key="g.id" class="acc__precand" role="treeitem" :aria-expanded="expandidos.has(g.id)">
-            <div class="acc__row acc__row--precand">
-              <button
-                type="button"
-                class="acc__cb"
-                :class="`acc__cb--${tri(idsDeGrupo(g.id))}`"
-                :aria-label="`Seleccionar todas las opciones de ${g.etiqueta}`"
-                @click="toggleSet(idsDeGrupo(g.id))"
-              ><span aria-hidden="true">{{ tri(idsDeGrupo(g.id)) === 'full' ? '✓' : tri(idsDeGrupo(g.id)) === 'partial' ? '–' : '' }}</span></button>
-              <button
-                type="button"
-                class="acc__expand"
-                :aria-expanded="expandidos.has(g.id)"
-                :aria-label="`${expandidos.has(g.id) ? 'Contraer' : 'Ver listas de'} ${g.etiqueta}`"
-                @click="toggleExpand(g.id)"
-              >
-                <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(g.id) ? '▾' : '▸' }}</span>
-                <span class="acc__etiqueta acc__etiqueta--precand">{{ g.etiqueta }}</span>
-              </button>
-            </div>
-            <ul v-if="expandidos.has(g.id)" class="acc__children" role="group">
-              <!-- Nivel intermedio 2 (sublema bajo precandidato en ODN): g1 → g2 → hoja -->
-              <li v-for="g2 in gruposDe(g.id)" :key="g2.id" class="acc__precand" role="treeitem" :aria-expanded="expandidos.has(g2.id)">
-                <div class="acc__row acc__row--sublema">
-                  <button
-                    type="button"
-                    class="acc__cb"
-                    :class="`acc__cb--${tri(idsDeGrupo(g2.id))}`"
-                    :aria-label="`Seleccionar todas las opciones de ${g2.etiqueta}`"
-                    @click="toggleSet(idsDeGrupo(g2.id))"
-                  ><span aria-hidden="true">{{ tri(idsDeGrupo(g2.id)) === 'full' ? '✓' : tri(idsDeGrupo(g2.id)) === 'partial' ? '–' : '' }}</span></button>
-                  <button
-                    type="button"
-                    class="acc__expand"
-                    :aria-expanded="expandidos.has(g2.id)"
-                    :aria-label="`${expandidos.has(g2.id) ? 'Contraer' : 'Ver listas de'} ${g2.etiqueta}`"
-                    @click="toggleExpand(g2.id)"
-                  >
-                    <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(g2.id) ? '▾' : '▸' }}</span>
-                    <span class="acc__etiqueta acc__etiqueta--precand">{{ g2.etiqueta }}</span>
-                  </button>
-                </div>
-                <ul v-if="expandidos.has(g2.id)" class="acc__children" role="group">
-                  <li v-for="h in opcionesDeGrupo(g2.id)" :key="h.id" class="acc__hoja" role="treeitem">
-                    <div class="acc__row acc__row--hoja2">
-                      <button
-                        type="button"
-                        class="acc__cb"
-                        :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
-                        :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
-                        @click="toggleHoja(h.id)"
-                      ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
-                      <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-              <!-- Hojas directas de g1 (sin sub-grupo): ODD/nacionales todas; ODN listas sin sublema -->
-              <li v-for="h in opcionesDeGrupo(g.id)" :key="h.id" class="acc__hoja" role="treeitem">
-                <div class="acc__row acc__row--hoja">
-                  <button
-                    type="button"
-                    class="acc__cb"
-                    :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
-                    :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
-                    @click="toggleHoja(h.id)"
-                  ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
-                  <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
-                </div>
-              </li>
-            </ul>
-          </li>
-          <!-- Opciones directas del lema (ODD: hoja; intendente: candidato; voto al lema) -->
-          <li v-for="h in opcionesDeLemaDirecto(l.id)" :key="h.id" class="acc__hoja" role="treeitem">
-            <div class="acc__row acc__row--hoja">
-              <button
-                type="button"
-                class="acc__cb"
-                :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
-                :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
-                @click="toggleHoja(h.id)"
-              ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
-              <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
-            </div>
-          </li>
-        </ul>
-      </li>
-    </ul>
+          <ul v-if="expandidos.has(l.id)" class="acc__children" role="group">
+            <!-- Nivel intermedio 1 (precandidato en ODN; sublema en ODD/nacionales): lema → g1 -->
+            <li v-for="g in gruposDe(l.id)" :key="g.id" class="acc__precand" role="treeitem" :aria-expanded="expandidos.has(g.id)">
+              <div class="acc__row acc__row--precand">
+                <button
+                  type="button"
+                  class="acc__cb"
+                  :class="`acc__cb--${tri(idsDeGrupo(g.id))}`"
+                  :aria-label="`Seleccionar todas las opciones de ${g.etiqueta}`"
+                  @click="toggleSet(idsDeGrupo(g.id))"
+                ><span aria-hidden="true">{{ tri(idsDeGrupo(g.id)) === 'full' ? '✓' : tri(idsDeGrupo(g.id)) === 'partial' ? '–' : '' }}</span></button>
+                <button
+                  type="button"
+                  class="acc__expand"
+                  :aria-expanded="expandidos.has(g.id)"
+                  :aria-label="`${expandidos.has(g.id) ? 'Contraer' : 'Ver listas de'} ${g.etiqueta}`"
+                  @click="toggleExpand(g.id)"
+                >
+                  <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(g.id) ? '▾' : '▸' }}</span>
+                  <span class="acc__etiqueta acc__etiqueta--precand">{{ g.etiqueta }}</span>
+                </button>
+              </div>
+              <ul v-if="expandidos.has(g.id)" class="acc__children" role="group">
+                <!-- Nivel intermedio 2 (sublema bajo precandidato en ODN): g1 → g2 → hoja -->
+                <li v-for="g2 in gruposDe(g.id)" :key="g2.id" class="acc__precand" role="treeitem" :aria-expanded="expandidos.has(g2.id)">
+                  <div class="acc__row acc__row--sublema">
+                    <button
+                      type="button"
+                      class="acc__cb"
+                      :class="`acc__cb--${tri(idsDeGrupo(g2.id))}`"
+                      :aria-label="`Seleccionar todas las opciones de ${g2.etiqueta}`"
+                      @click="toggleSet(idsDeGrupo(g2.id))"
+                    ><span aria-hidden="true">{{ tri(idsDeGrupo(g2.id)) === 'full' ? '✓' : tri(idsDeGrupo(g2.id)) === 'partial' ? '–' : '' }}</span></button>
+                    <button
+                      type="button"
+                      class="acc__expand"
+                      :aria-expanded="expandidos.has(g2.id)"
+                      :aria-label="`${expandidos.has(g2.id) ? 'Contraer' : 'Ver listas de'} ${g2.etiqueta}`"
+                      @click="toggleExpand(g2.id)"
+                    >
+                      <span class="acc__chevron" aria-hidden="true">{{ expandidos.has(g2.id) ? '▾' : '▸' }}</span>
+                      <span class="acc__etiqueta acc__etiqueta--precand">{{ g2.etiqueta }}</span>
+                    </button>
+                  </div>
+                  <ul v-if="expandidos.has(g2.id)" class="acc__children" role="group">
+                    <li v-for="h in opcionesDeGrupo(g2.id)" :key="h.id" class="acc__hoja" role="treeitem">
+                      <div class="acc__row acc__row--hoja2">
+                        <button
+                          type="button"
+                          class="acc__cb"
+                          :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
+                          :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
+                          @click="toggleHoja(h.id)"
+                        ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
+                        <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
+                      </div>
+                    </li>
+                  </ul>
+                </li>
+                <!-- Hojas directas de g1 (sin sub-grupo): ODD/nacionales todas; ODN listas sin sublema -->
+                <li v-for="h in opcionesDeGrupo(g.id)" :key="h.id" class="acc__hoja" role="treeitem">
+                  <div class="acc__row acc__row--hoja">
+                    <button
+                      type="button"
+                      class="acc__cb"
+                      :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
+                      :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
+                      @click="toggleHoja(h.id)"
+                    ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
+                    <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
+                  </div>
+                </li>
+              </ul>
+            </li>
+            <!-- Opciones directas del lema (ODD: hoja; intendente: candidato; voto al lema) -->
+            <li v-for="h in opcionesDeLemaDirecto(l.id)" :key="h.id" class="acc__hoja" role="treeitem">
+              <div class="acc__row acc__row--hoja">
+                <button
+                  type="button"
+                  class="acc__cb"
+                  :class="seleccion.has(h.id) ? 'acc__cb--full' : 'acc__cb--empty'"
+                  :aria-label="`Seleccionar ${etiquetaOpcion(h)}`"
+                  @click="toggleHoja(h.id)"
+                ><span aria-hidden="true">{{ seleccion.has(h.id) ? '✓' : '' }}</span></button>
+                <span class="acc__lista">{{ etiquetaOpcion(h) }}</span>
+              </div>
+            </li>
+          </ul>
+        </li>
+      </ul>
 
-    <!-- Tipo plano (balotaje/plebiscito): lista simple de opciones con checkbox, sin chevrons -->
-    <ul v-else-if="contienda && esPlano" class="acc__tree acc__tree--plano" role="group">
-      <li v-for="o in opcionesPlano" :key="o.id" class="acc__hoja">
-        <div class="acc__row">
-          <button
-            type="button"
-            class="acc__cb"
-            :class="seleccion.has(o.id) ? 'acc__cb--full' : 'acc__cb--empty'"
-            :aria-label="`Seleccionar ${metaPlano(o).label}`"
-            @click="toggleHoja(o.id)"
-          ><span aria-hidden="true">{{ seleccion.has(o.id) ? '✓' : '' }}</span></button>
-          <img v-if="metaPlano(o).flagUrl" :src="metaPlano(o).flagUrl!" :alt="metaPlano(o).sigla" class="acc__flag" aria-hidden="true" />
-          <span v-else class="acc__swatch" :style="{ background: metaPlano(o).color }" aria-hidden="true"></span>
-          <span class="acc__lista">{{ metaPlano(o).label }}</span>
-        </div>
-      </li>
-    </ul>
+      <!-- Tipo plano (balotaje/plebiscito): lista simple de opciones con checkbox, sin chevrons -->
+      <ul v-else-if="contienda && esPlano" class="acc__tree acc__tree--plano" role="group">
+        <li v-for="o in opcionesPlano" :key="o.id" class="acc__hoja">
+          <div class="acc__row">
+            <button
+              type="button"
+              class="acc__cb"
+              :class="seleccion.has(o.id) ? 'acc__cb--full' : 'acc__cb--empty'"
+              :aria-label="`Seleccionar ${metaPlano(o).label}`"
+              @click="toggleHoja(o.id)"
+            ><span aria-hidden="true">{{ seleccion.has(o.id) ? '✓' : '' }}</span></button>
+            <img v-if="metaPlano(o).flagUrl" :src="metaPlano(o).flagUrl!" :alt="metaPlano(o).sigla" class="acc__flag" aria-hidden="true" />
+            <span v-else class="acc__swatch" :style="{ background: metaPlano(o).color }" aria-hidden="true"></span>
+            <span class="acc__lista">{{ metaPlano(o).label }}</span>
+          </div>
+        </li>
+      </ul>
 
-    <p v-if="!catalogo" class="acc__cargando">Cargando opciones…</p>
+      <p v-if="!catalogo" class="acc__cargando">Cargando opciones…</p>
+
+      <!-- Acciones: footer bajo el árbol (mismo v-if, mismos handlers que antes) -->
+      <div v-if="contienda && !esPlano" class="acc__acciones">
+        <button class="acc__btn" type="button" @click="seleccionarTodasVisibles">
+          <span aria-hidden="true">☑</span> Seleccionar todas
+        </button>
+        <button class="acc__btn acc__btn--ghost" type="button" :disabled="seleccion.size === 0" @click="limpiarTodo">
+          <span aria-hidden="true">✕</span> Limpiar<span v-if="seleccion.size"> ({{ seleccion.size }})</span>
+        </button>
+      </div>
+
     </div>
   </section>
 </template>
 
 <style scoped>
-.acc { padding: 0.5rem 1rem; border-bottom: 1px solid var(--color-border); font-size: 0.875rem; }
+/* ── Contenedor ────────────────────────────────────────────────────────────── */
+.acc {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.8125rem;
+  font-family: var(--font-ui);
+}
+
+/* ── Header toggle ─────────────────────────────────────────────────────────── */
 .acc__toggle {
   display: flex; align-items: center; gap: 0.5rem; width: 100%;
   background: none; border: none; padding: 0.25rem 0; margin: 0; cursor: pointer;
-  text-align: left; color: inherit; min-height: 36px;
+  text-align: left; color: inherit; min-height: 32px;
 }
-.acc__toggle-chevron { color: var(--color-ink-faint); font-size: 0.75rem; transition: transform 0.15s ease; flex: none; }
+.acc__toggle-chevron {
+  color: var(--color-ink-faint); font-size: 0.7rem; flex: none;
+  display: inline-block;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .acc__toggle-chevron { transition: transform 0.15s ease; }
+}
 .acc__toggle-chevron--open { transform: rotate(90deg); }
 .acc__toggle-lbl {
-  font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+  font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
   color: var(--color-ink-muted);
 }
 .acc__toggle-badge {
-  margin-left: auto; font-size: 0.6875rem; font-weight: 700; color: var(--color-paper);
-  background: var(--color-ink); border-radius: 9999px; padding: 0.0625rem 0.5rem;
+  margin-left: auto; font-size: 0.6875rem; font-weight: 700;
+  color: var(--color-card);
+  background: var(--color-accent);
+  border-radius: 9999px; padding: 0.075rem 0.5rem;
 }
-.acc__body { margin-top: 0.5rem; }
-.acc__contiendas { display: flex; gap: 0.25rem; margin-bottom: 0.5rem; }
+.acc__toggle:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; border-radius: var(--radius-sm); }
+
+/* ── Body ──────────────────────────────────────────────────────────────────── */
+.acc__body { margin-top: 0.375rem; }
+
+/* ── Tabs de contienda: estilo .seg track ──────────────────────────────────── */
+.acc__contiendas {
+  display: flex; gap: 2px;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius); padding: 3px;
+  margin-bottom: 0.5rem;
+}
 .acc__contienda {
-  flex: 1; padding: 0.375rem 0.5rem; border: 1px solid var(--color-border-strong);
-  border-radius: 0.25rem; background: var(--color-surface-1); color: var(--color-ink-soft);
-  font-size: 0.75rem; font-weight: 600; cursor: pointer; min-height: 36px;
+  flex: 1; padding: 5px 0.5rem;
+  border: none; border-radius: calc(var(--radius) - 2px);
+  background: transparent; color: var(--color-ink-muted);
+  font-size: 0.72rem; font-weight: 600; cursor: pointer;
+  font-family: var(--font-ui);
+  white-space: nowrap;
 }
-.acc__contienda--activa { background: var(--color-ink); color: var(--color-paper); border-color: var(--color-ink); }
-.acc__contienda:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
-
-.acc__controles { display: flex; flex-wrap: wrap; gap: 0.375rem; margin-bottom: 0.375rem; }
-.acc__busqueda { flex: 1 1 9rem; min-width: 9rem; padding: 0.375rem 0.5rem; border: 1px solid var(--color-border); border-radius: 0.25rem; min-height: 36px; }
-.acc__filtro { flex: 1 1 9rem; padding: 0.375rem 0.5rem; border: 1px solid var(--color-border); border-radius: 0.25rem; min-height: 36px; }
-
-.acc__chips { display: flex; flex-wrap: wrap; align-items: center; gap: 0.375rem; margin-bottom: 0.375rem; font-size: 0.75rem; }
-.acc__chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.125rem 0.5rem; border: 1px solid var(--color-border-strong); border-radius: 9999px; background: var(--color-surface-1); }
-.acc__chip--sel { font-weight: 700; }
-.acc__chip button { background: none; border: none; cursor: pointer; color: var(--color-ink-muted); padding: 0 0.125rem; }
-
-/* Acciones como botones claros (antes links de texto poco visibles) */
-.acc__acciones { display: flex; gap: 0.375rem; margin-bottom: 0.375rem; }
-.acc__btn {
-  display: inline-flex; align-items: center; gap: 0.375rem; padding: 0.375rem 0.625rem;
-  border: 1px solid var(--color-border-strong); border-radius: 0.375rem;
-  background: var(--color-surface-1); color: var(--color-ink); font-size: 0.75rem; font-weight: 600;
-  cursor: pointer; min-height: 34px;
+@media (prefers-reduced-motion: no-preference) {
+  .acc__contienda { transition: background 0.12s, color 0.12s, box-shadow 0.12s; }
 }
-.acc__btn:hover { background: var(--color-surface-2); }
-.acc__btn:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
-.acc__btn--ghost { background: none; color: var(--color-ink-soft); }
-.acc__btn:disabled { opacity: 0.45; cursor: default; }
-.acc__btn:disabled:hover { background: none; }
+.acc__contienda:hover { color: var(--color-ink); }
+.acc__contienda--activa {
+  background: var(--color-card);
+  color: var(--color-ink);
+  box-shadow: var(--shadow-sm);
+}
+.acc__contienda:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 1px; }
 
-.acc__tree { list-style: none; margin: 0; padding: 0; max-height: 22rem; overflow-y: auto; border: 1px solid var(--color-border); border-radius: 0.375rem; }
+/* ── Controles: búsqueda + filtro apilados ─────────────────────────────────── */
+.acc__controles { display: flex; flex-direction: column; gap: 0.3125rem; margin-bottom: 0.375rem; }
+.acc__busqueda,
+.acc__filtro {
+  width: 100%; padding: 0 0.5rem;
+  height: 30px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  color: var(--color-ink);
+  font-size: 0.8125rem;
+  font-family: var(--font-ui);
+}
+.acc__busqueda::placeholder { color: var(--color-ink-faint); }
+@media (prefers-reduced-motion: no-preference) {
+  .acc__busqueda, .acc__filtro { transition: border-color 0.12s; }
+}
+.acc__busqueda:focus-visible,
+.acc__filtro:focus-visible {
+  outline: 2px solid var(--color-focus); outline-offset: 1px;
+  border-color: var(--color-focus);
+}
+
+/* ── Chips ─────────────────────────────────────────────────────────────────── */
+.acc__chips {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: 0.3125rem; margin-bottom: 0.375rem; font-size: 0.72rem;
+}
+.acc__chip {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 9999px;
+  background: var(--color-surface-1);
+  color: var(--color-ink-soft);
+}
+.acc__chip--sel { font-weight: 700; color: var(--color-ink); }
+.acc__chip button {
+  background: none; border: none; cursor: pointer;
+  color: var(--color-ink-muted); padding: 0 0.1rem; line-height: 1;
+  font-size: 0.75rem;
+}
+.acc__chip button:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 1px; border-radius: 2px; }
+
+/* ── Nota de degradado ─────────────────────────────────────────────────────── */
+.acc__degradado {
+  font-size: 0.6875rem; color: var(--color-ink-faint); font-style: italic;
+  margin: 0 0 0.3125rem; line-height: 1.4;
+}
+
+/* ── Árbol ─────────────────────────────────────────────────────────────────── */
+.acc__tree {
+  list-style: none; margin: 0; padding: 0;
+  max-height: 22.5rem; /* ~360px */
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-strong) transparent;
+}
 .acc__children { list-style: none; margin: 0; padding: 0; }
-.acc__row { display: flex; align-items: center; gap: 0.375rem; min-height: 40px; padding: 0.125rem 0.375rem; border-bottom: 1px solid var(--color-surface-2); }
+
+/* Filas: más bajas y compactas */
+.acc__row {
+  display: flex; align-items: center; gap: 0.3125rem;
+  min-height: 30px; padding: 0.0625rem 0.375rem;
+  border-bottom: 1px solid var(--color-surface-2);
+}
 .acc__row--lema { font-weight: 600; }
-.acc__row--precand { padding-left: 1.75rem; }
-.acc__row--sublema { padding-left: 3rem; }
-.acc__row--hoja { padding-left: 3rem; }
-.acc__row--hoja2 { padding-left: 4.25rem; }
+.acc__row--precand { padding-left: 1.375rem; }
+.acc__row--sublema { padding-left: 2.5rem; }
+.acc__row--hoja   { padding-left: 2.5rem; }
+.acc__row--hoja2  { padding-left: 3.625rem; }
 .acc__tree--plano .acc__row { padding-left: 0.375rem; }
 
+/* ── Checkbox tri-estado ───────────────────────────────────────────────────── */
 .acc__cb {
-  width: 22px; height: 22px; flex-shrink: 0; border: 1.5px solid var(--color-border-strong);
-  border-radius: 0.25rem; background: var(--color-paper); cursor: pointer; display: grid; place-items: center;
-  font-size: 0.8rem; line-height: 1; color: var(--color-paper);
+  width: 18px; height: 18px; flex-shrink: 0;
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  cursor: pointer; display: grid; place-items: center;
+  font-size: 0.7rem; line-height: 1;
+  color: var(--color-paper);
 }
-.acc__cb--full { background: var(--color-ink); border-color: var(--color-ink); }
+@media (prefers-reduced-motion: no-preference) {
+  .acc__cb { transition: background 0.1s, border-color 0.1s; }
+}
+.acc__cb--full    { background: var(--color-ink); border-color: var(--color-ink); }
 .acc__cb--partial { background: var(--color-ink-soft); border-color: var(--color-ink-soft); }
 .acc__cb:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
 
-/* Rótulo del lema/grupo: toda la fila (chevron + bandera + nombre) abre el desglose */
+/* ── Botón expandir lema/grupo ─────────────────────────────────────────────── */
 .acc__expand {
-  display: flex; align-items: center; gap: 0.375rem; flex: 1; min-width: 0;
+  display: flex; align-items: center; gap: 0.3125rem; flex: 1; min-width: 0;
   background: none; border: none; cursor: pointer; text-align: left;
-  min-height: 40px; padding: 0 0.25rem; border-radius: 0.25rem; color: inherit; font: inherit;
+  min-height: 30px; padding: 0 0.25rem;
+  border-radius: var(--radius-sm); color: inherit;
+  font: inherit; font-family: var(--font-ui);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .acc__expand { transition: background 0.1s; }
 }
 .acc__expand:hover { background: var(--color-surface-2); }
 .acc__expand:focus-visible { outline: 2px solid var(--color-focus); outline-offset: -2px; }
-.acc__chevron { width: 0.9rem; flex-shrink: 0; color: var(--color-ink-soft); font-size: 0.7rem; }
 
-.acc__swatch { width: 0.75rem; height: 0.75rem; border-radius: 0.125rem; flex-shrink: 0; border: 1px solid rgba(0,0,0,.1); }
-.acc__flag  { width: 1.25rem; height: 0.8125rem; border-radius: 0.125rem; flex-shrink: 0; border: 1px solid rgba(0,0,0,.15); object-fit: cover; }
-.acc__sigla { font-weight: 700; min-width: 2.25rem; color: var(--color-ink); }
-.acc__etiqueta { flex: 1; min-width: 0; color: var(--color-ink-soft); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.acc__etiqueta--precand { font-weight: 500; color: var(--color-ink); }
-.acc__lista { color: var(--color-ink); }
+.acc__chevron { width: 0.875rem; flex-shrink: 0; color: var(--color-ink-faint); font-size: 0.65rem; }
 
-.acc__cargando { color: var(--color-ink-faint); font-size: 0.8125rem; margin: 0.5rem 0; }
-.acc__degradado { font-size: 0.7rem; color: var(--color-ink-faint); font-style: italic; margin: 0 0 0.375rem; }
+/* ── Indicadores visuales del partido ─────────────────────────────────────── */
+.acc__swatch {
+  width: 0.75rem; height: 0.75rem;
+  border-radius: var(--radius-sm); flex-shrink: 0;
+  border: 1px solid var(--color-border);
+}
+.acc__flag {
+  width: 1.25rem; height: 0.8125rem;
+  border-radius: var(--radius-sm); flex-shrink: 0;
+  border: 1px solid var(--color-border);
+  object-fit: cover;
+}
+
+/* ── Texto en el árbol ─────────────────────────────────────────────────────── */
+.acc__sigla {
+  font-weight: 700; min-width: 2rem; color: var(--color-ink);
+  font-size: 0.75rem;
+}
+.acc__etiqueta {
+  flex: 1; min-width: 0; color: var(--color-ink-soft);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 0.8125rem;
+}
+.acc__etiqueta--precand { font-weight: 600; color: var(--color-ink); }
+.acc__lista { color: var(--color-ink); font-size: 0.8125rem; flex: 1; min-width: 0; }
+
+/* ── Cargando ──────────────────────────────────────────────────────────────── */
+.acc__cargando { color: var(--color-ink-faint); font-size: 0.8125rem; margin: 0.4rem 0; }
+
+/* ── Footer de acciones (bajo el árbol) ────────────────────────────────────── */
+.acc__acciones {
+  display: flex; gap: 0.3125rem;
+  border-top: 1px solid var(--color-border);
+  margin-top: 0.3125rem; padding-top: 0.375rem;
+}
+.acc__btn {
+  display: inline-flex; align-items: center; gap: 0.3125rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-1); color: var(--color-ink);
+  font-size: 0.75rem; font-weight: 600;
+  font-family: var(--font-ui);
+  cursor: pointer; min-height: 28px;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .acc__btn { transition: background 0.1s; }
+}
+.acc__btn:hover { background: var(--color-surface-2); }
+.acc__btn:focus-visible { outline: 2px solid var(--color-focus); outline-offset: 2px; }
+.acc__btn--ghost { background: none; border-color: transparent; color: var(--color-ink-soft); }
+.acc__btn--ghost:hover { background: var(--color-surface-2); border-color: var(--color-border); }
+.acc__btn:disabled { opacity: 0.4; cursor: default; }
+.acc__btn:disabled:hover { background: none; border-color: transparent; }
 </style>

--- a/src/components/sheet/ZoneSheet.vue
+++ b/src/components/sheet/ZoneSheet.vue
@@ -29,6 +29,7 @@ interface ResultadoLinea {
 interface SelInfo {
   geoId: string;
   label?: string;
+  nivelLabel?: string;
   sigla: string;
   nombre: string;
   color: string;
@@ -131,13 +132,18 @@ function pctEmit(n: number): string {
 
       <header class="zone-sheet__header">
         <button
-          class="zone-sheet__plegar"
+          class="zone-sheet__toggle"
           type="button"
           :aria-expanded="bodyOpen"
-          :aria-label="bodyOpen ? 'Plegar detalle' : 'Desplegar detalle'"
+          :aria-label="bodyOpen ? 'Plegar detalle de la zona' : 'Desplegar detalle de la zona'"
           @click="bodyOpen = !bodyOpen"
-        ><span class="zone-sheet__chevron" :class="{ 'zone-sheet__chevron--open': bodyOpen }" aria-hidden="true">▸</span></button>
-        <h2 class="zone-sheet__titulo">{{ sel.label ?? sel.geoId }}</h2>
+        >
+          <span class="zone-sheet__chevron" :class="{ 'zone-sheet__chevron--open': bodyOpen }" aria-hidden="true">▸</span>
+          <span class="zone-sheet__titles">
+            <span class="zone-sheet__kicker">{{ sel.nivelLabel ?? 'Zona' }}</span>
+            <span class="zone-sheet__titulo">{{ sel.label ?? sel.geoId }}</span>
+          </span>
+        </button>
         <button
           class="zone-sheet__cerrar"
           type="button"
@@ -345,17 +351,14 @@ function pctEmit(n: number): string {
 <style scoped>
 .zone-sheet {
   background: var(--color-card);
-  border-radius: var(--radius-lg);
+  border-top: 1px solid var(--color-border);
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.25s ease;
 }
-/* Epic 23: card del rail solo cuando hay zona abierta (colapsada no deja artefacto). */
+/* Sin scroll: se ve todo el contenido (max-height alto solo para animar el colapso). */
 .zone-sheet--open {
-  max-height: 420px;
-  overflow-y: auto;
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-sm);
+  max-height: 2000px;
 }
 
 /* Mobile: bottom sheet fijo */
@@ -395,27 +398,52 @@ function pctEmit(n: number): string {
   border-bottom: 1px solid var(--color-surface-2);
 }
 
-.zone-sheet__plegar {
+/* Toda la fila título es el toggle (plegable como ResultadoGlobal/OpcionAccordion). */
+.zone-sheet__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
   background: none;
   border: none;
-  padding: 0 0.5rem 0 0;
+  padding: 0;
   margin: 0;
   cursor: pointer;
-  color: var(--color-ink-faint);
-  flex: none;
+  text-align: left;
+  color: inherit;
 }
 .zone-sheet__chevron {
   display: inline-block;
   font-size: 0.8125rem;
+  color: var(--color-ink-faint);
   transition: transform 0.15s ease;
+  flex: none;
 }
 .zone-sheet__chevron--open { transform: rotate(90deg); }
+.zone-sheet__titles {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.zone-sheet__kicker {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-ink-muted);
+  line-height: 1.2;
+}
 .zone-sheet__titulo {
-  font-size: 1rem;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: 1.0625rem;
   font-weight: 700;
   color: var(--color-ink);
   margin: 0;
-  margin-right: auto;
+  line-height: 1.15;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .zone-sheet__cerrar {

--- a/src/components/sheet/ZoneSheet.vue
+++ b/src/components/sheet/ZoneSheet.vue
@@ -345,14 +345,17 @@ function pctEmit(n: number): string {
 <style scoped>
 .zone-sheet {
   background: var(--color-card);
-  border-top: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.25s ease;
 }
+/* Epic 23: card del rail solo cuando hay zona abierta (colapsada no deja artefacto). */
 .zone-sheet--open {
   max-height: 420px;
   overflow-y: auto;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Mobile: bottom sheet fijo */

--- a/src/components/sheet/ZoneSheet.vue
+++ b/src/components/sheet/ZoneSheet.vue
@@ -91,14 +91,36 @@ function titleCase(s: string): string {
     .join(' ');
 }
 
-// Sigla legible del lema para el Concejo Municipal (los miembros traen el lema como slug).
+// Sigla legible del lema para el Concejo Municipal. Los miembros traen el lema como slug BARE
+// (post sweep-party-consistency): 'nacional', 'frente-amplio', etc. (sin prefijo 'partido-').
 const LEMA_SIGLA: Record<string, string> = {
-  'frente-amplio': 'FA', 'partido-nacional': 'PN', 'partido-colorado': 'PC',
-  'coalicion-republicana': 'CR', 'cabildo-abierto': 'CA', 'partido-independiente': 'PI',
-  'asamblea-popular': 'AP', 'partido-ecologista-radical-intransigente': 'PERI',
+  'frente-amplio': 'FA', 'nacional': 'PN', 'colorado': 'PC',
+  'coalicion-republicana': 'CR', 'cabildo-abierto': 'CA', 'independiente': 'PI',
+  'asamblea-popular': 'AP', 'ecologista-radical-intransigente': 'PERI',
+  'avanzar-republicano': 'AR', 'constitucional-ambientalista': 'PCA',
+  'por-los-cambios-necesarios-pcn': 'PCN', 'identidad-soberana': 'IS',
+  'de-los-trabajadores': 'PT', 'trabajadores': 'PT',
 };
+// Nombre completo del partido por sigla (para el título accesible del Concejo).
+const SIGLA_NOMBRE: Record<string, string> = {
+  FA: 'Frente Amplio', PN: 'Partido Nacional', PC: 'Partido Colorado',
+  CR: 'Coalición Republicana', CA: 'Cabildo Abierto', PI: 'Partido Independiente',
+  AP: 'Asamblea Popular', PERI: 'Partido Ecologista Radical Intransigente',
+  AR: 'Avanzar Republicano', PCA: 'Partido Constitucional Ambientalista',
+  PCN: 'Por los Cambios Necesarios', IS: 'Identidad Soberana', PT: 'Partido de los Trabajadores',
+};
+// Siglas con archivo de bandera en public/flags/.
+const FLAG_SIGLAS = new Set(['AP', 'AR', 'CA', 'CR', 'FA', 'IS', 'PC', 'PCA', 'PCN', 'PERI', 'PI', 'PN', 'PT']);
 function lemaSigla(slug: string): string {
   return LEMA_SIGLA[slug] ?? titleCase(slug.replace(/-/g, ' '));
+}
+function lemaNombre(slug: string): string {
+  const s = LEMA_SIGLA[slug];
+  return (s && SIGLA_NOMBRE[s]) ?? lemaSigla(slug);
+}
+function lemaFlag(slug: string): string | null {
+  const s = LEMA_SIGLA[slug];
+  return s && FLAG_SIGLAS.has(s) ? `/flags/${s.toLowerCase()}.svg` : null;
 }
 
 /** % de los votos válidos de la zona (mismo denominador que el ganador y la selección). */
@@ -259,7 +281,17 @@ function pctEmit(n: number): string {
             >
               <span class="zone-sheet__concejo-cargo">{{ m.cargo === 'alcalde' ? 'Alcalde' : 'Concejal' }}</span>
               <span class="zone-sheet__concejo-nombre">{{ titleCase(m.nombre) }}</span>
-              <span class="zone-sheet__concejo-lema">{{ lemaSigla(m.lema) }} · {{ m.hoja }}</span>
+              <span class="zone-sheet__concejo-lema" :title="`${lemaNombre(m.lema)} · hoja ${m.hoja}`">
+                <img
+                  v-if="lemaFlag(m.lema)"
+                  :src="lemaFlag(m.lema)!"
+                  :alt="lemaNombre(m.lema)"
+                  class="zone-sheet__concejo-flag"
+                  aria-hidden="true"
+                />
+                <span class="zone-sheet__concejo-sigla">{{ lemaSigla(m.lema) }}</span>
+                <span class="zone-sheet__concejo-hoja">{{ m.hoja }}</span>
+              </span>
             </li>
           </ul>
         </div>
@@ -651,7 +683,24 @@ function pctEmit(n: number): string {
 }
 .zone-sheet__concejo-item--alcalde .zone-sheet__concejo-cargo { color: var(--color-ink-soft); }
 .zone-sheet__concejo-nombre { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.zone-sheet__concejo-lema { color: var(--color-ink-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.zone-sheet__concejo-lema {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+  flex: none;
+}
+.zone-sheet__concejo-flag {
+  width: 1.125rem;
+  height: 0.75rem;
+  border-radius: 0.125rem;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+  flex: none;
+}
+.zone-sheet__concejo-sigla { font-weight: 700; color: var(--color-ink-soft); }
+.zone-sheet__concejo-hoja { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
 
 .zone-sheet__opcion-activa {
   font-size: 0.8125rem;

--- a/src/components/ui/ThemeToggle.vue
+++ b/src/components/ui/ThemeToggle.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+/**
+ * Epic 23 · Story 23.5 — Toggle de tema (claro / oscuro / auto).
+ * Persiste el modo en localStorage ('ui:theme') y delega la aplicación del data-theme
+ * al script anti-flash de Base.astro (window.__applyTheme), para una sola fuente de verdad.
+ */
+import { onMounted, ref } from 'vue';
+
+type Mode = 'auto' | 'light' | 'dark';
+const KEY = 'ui:theme';
+const ORDER: Mode[] = ['auto', 'light', 'dark'];
+const LABEL: Record<Mode, string> = { auto: 'Tema: automático', light: 'Tema: claro', dark: 'Tema: oscuro' };
+
+// SSR-safe: arranca en 'auto' y sincroniza al montar (evita hydration mismatch).
+const mode = ref<Mode>('auto');
+
+onMounted(() => {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === 'light' || v === 'dark' || v === 'auto') mode.value = v;
+  } catch { /* ignore */ }
+});
+
+function cycle() {
+  const next = ORDER[(ORDER.indexOf(mode.value) + 1) % ORDER.length];
+  mode.value = next;
+  try { localStorage.setItem(KEY, next); } catch { /* ignore */ }
+  (window as unknown as { __applyTheme?: () => void }).__applyTheme?.();
+}
+</script>
+
+<template>
+  <button
+    class="theme-toggle"
+    type="button"
+    :title="LABEL[mode]"
+    :aria-label="LABEL[mode]"
+    @click="cycle"
+  >
+    <!-- auto: medio sol/luna -->
+    <svg v-if="mode === 'auto'" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.8" />
+      <path d="M12 4a8 8 0 0 0 0 16z" fill="currentColor" />
+    </svg>
+    <!-- claro: sol -->
+    <svg v-else-if="mode === 'light'" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="4.2" stroke="currentColor" stroke-width="1.8" />
+      <g stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+        <path d="M12 2.5v2.2M12 19.3v2.2M21.5 12h-2.2M4.7 12H2.5M18.7 5.3l-1.6 1.6M6.9 17.1l-1.6 1.6M18.7 18.7l-1.6-1.6M6.9 6.9 5.3 5.3" />
+      </g>
+    </svg>
+    <!-- oscuro: luna -->
+    <svg v-else viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M20 14.5A8 8 0 0 1 9.5 4a7 7 0 1 0 10.5 10.5z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
+    </svg>
+  </button>
+</template>
+
+<style scoped>
+.theme-toggle {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius);
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.theme-toggle:hover {
+  background: var(--color-surface-2);
+  border-color: var(--color-border);
+  color: var(--color-ink);
+}
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+.theme-toggle svg { width: 19px; height: 19px; }
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -44,6 +44,9 @@ const canonicalUrl = canonical ? `${siteUrl}${canonical}` : undefined;
         }
         apply();
         window.__applyTheme = apply;
+        // Astro ClientRouter (SPA) reemplaza el DOM al navegar y descarta el data-theme del
+        // <html> → re-aplicarlo tras cada swap para que el tema persista entre páginas.
+        document.addEventListener('astro:after-swap', apply);
         try {
           window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
             var mode = 'auto';

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -27,6 +27,32 @@ const canonicalUrl = canonical ? `${siteUrl}${canonical}` : undefined;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
+    <!-- Epic 23 · Story 23.5 — tema anti-flash: pone data-theme en <html> antes del paint.
+         Modo en localStorage ('light'|'dark'|'auto', default auto = sistema). -->
+    <script is:inline>
+      (function () {
+        var KEY = 'ui:theme';
+        var root = document.documentElement;
+        function effective(mode) {
+          if (mode === 'light' || mode === 'dark') return mode;
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        function apply() {
+          var mode = 'auto';
+          try { mode = localStorage.getItem(KEY) || 'auto'; } catch (e) {}
+          root.setAttribute('data-theme', effective(mode));
+        }
+        apply();
+        window.__applyTheme = apply;
+        try {
+          window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+            var mode = 'auto';
+            try { mode = localStorage.getItem(KEY) || 'auto'; } catch (e) {}
+            if (mode === 'auto') apply();
+          });
+        } catch (e) {}
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&display=swap" rel="stylesheet" />

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -103,7 +103,7 @@ const canonicalPath = `/${eleccion}/${departamento}`;
   ogImage={ogImagePath}
   canonical={canonicalPath}
 >
-  <main id="main-content" class="mx-auto max-w-3xl">
+  <main id="main-content" class="mx-auto max-w-3xl lg:max-w-6xl">
     <header class="masthead">
       <div>
         <h1 class="masthead__dept">{deptLabel}</h1>

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -142,8 +142,6 @@ const canonicalPath = `/${eleccion}/${departamento}`;
       eleccionActual={eleccion}
       departamento={departamento}
     />
-    <!-- Toggle Zonas/Circuito (nivel geográfico) — control del mapa: va PEGADO arriba del mapa. -->
-    <LevelSelector client:idle availableLevels={availableLevels} />
     <!-- Comparación entre elecciones (prototipo Fase 1): dropdown de elecciones del mismo tipo;
          marca con borde naranja las zonas donde cambió el partido ganador. -->
     <CompareControls
@@ -151,9 +149,10 @@ const canonicalPath = `/${eleccion}/${departamento}`;
       availableElecciones={availableElecciones}
       eleccionActual={eleccion}
     />
-    <!-- Control de listas/partido (Epic UX): ARRIBA del mapa, plegable y colapsado por defecto
-         (decisión de Juan). Sincroniza con el mapa por el store, así que su posición no afecta. -->
+    <!-- Control de listas/partido (Epic UX): plegable y colapsado por defecto. -->
     <OpcionAccordion client:idle eleccion={eleccion} departamento={departamento} />
+    <!-- Toggle Zonas/Circuito (nivel geográfico) — va ABAJO del filtro, pegado al mapa (pedido de Juan). -->
+    <LevelSelector client:idle availableLevels={availableLevels} />
     <!-- Map-first: el mapa (héroe) queda visible sin scrollear (el control de arriba va colapsado).
          transition:persist con nombre ESTABLE ("map") → el island MapLibre sobrevive la navegación
          entre departamentos aunque vaya antes en el DOM (NFR1). -->

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -9,6 +9,7 @@ import EleccionSelector from '../../components/selectors/EleccionSelector.vue';
 import CompareControls from '../../components/map/CompareControls.vue';
 import Sello from '../../components/ui/Sello.astro';
 import ShareButton from '../../components/share/ShareButton.vue';
+import ThemeToggle from '../../components/ui/ThemeToggle.vue';
 import ExportButton from '../../components/share/ExportButton.vue';
 import MapScreenshotButton from '../../components/share/MapScreenshotButton.vue';
 import deptsConfig from '../../config/departments.json';
@@ -109,7 +110,10 @@ const canonicalPath = `/${eleccion}/${departamento}`;
         <h1 class="masthead__dept">{deptLabel}</h1>
         <p class="masthead__eleccion">{eleccionLabel}</p>
       </div>
-      <ShareButton client:idle />
+      <div class="masthead__actions">
+        <ThemeToggle client:idle />
+        <ShareButton client:idle />
+      </div>
     </header>
     <!-- Pregunta del plebiscito/referéndum como contexto (Story 7.5) -->
     {preguntaPlebiscito && (

--- a/src/pages/[eleccion]/[departamento].astro
+++ b/src/pages/[eleccion]/[departamento].astro
@@ -104,7 +104,7 @@ const canonicalPath = `/${eleccion}/${departamento}`;
   ogImage={ogImagePath}
   canonical={canonicalPath}
 >
-  <main id="main-content" class="mx-auto max-w-3xl lg:max-w-6xl">
+  <main id="main-content" class="mx-auto max-w-3xl">
     <header class="masthead">
       <div>
         <h1 class="masthead__dept">{deptLabel}</h1>

--- a/src/pages/[eleccion]/index.astro
+++ b/src/pages/[eleccion]/index.astro
@@ -115,12 +115,12 @@ const canonicalPath = `/${eleccion}`;
       eleccionActual={eleccion}
       departamento="_nacional"
     />
-    <!-- Toggle Departamentos/Zonas — control del mapa: va PEGADO arriba del mapa (Story 15.4).
+    <!-- Control de listas/partido (Epic UX): plegable y colapsado por defecto. -->
+    <OpcionAccordion client:idle eleccion={eleccion} departamento="_nacional" />
+    <!-- Toggle Departamentos/Zonas — va ABAJO del filtro, pegado al mapa (Story 15.4, pedido de Juan).
          No aplica a Municipales (nivel único 'municipio') ni a elecciones sin nivel zona nacional
          (p.ej. departamentales-2015, que solo tiene agregado por departamento). -->
     {!esMunicipales && hayZonaNacional && <GranularitySelector client:idle />}
-    <!-- Control de listas/partido (Epic UX): ARRIBA del mapa, plegable y colapsado por defecto. -->
-    <OpcionAccordion client:idle eleccion={eleccion} departamento="_nacional" />
     <!-- Map-first: el mapa va arriba de los selectores para quedar visible sin scrollear.
          persist con nombre propio ("map-nacional") → persiste entre elecciones nacionales pero
          NO cruza con la vista por-depto (que debe re-inicializar). -->

--- a/src/pages/[eleccion]/index.astro
+++ b/src/pages/[eleccion]/index.astro
@@ -84,7 +84,7 @@ const canonicalPath = `/${eleccion}`;
 ---
 
 <Base title={titulo} description={descripcion} canonical={canonicalPath}>
-  <main id="main-content" class="mx-auto max-w-3xl">
+  <main id="main-content" class="mx-auto max-w-3xl lg:max-w-6xl">
     <header class="masthead">
       <div>
         <h1 class="masthead__dept">Uruguay</h1>

--- a/src/pages/[eleccion]/index.astro
+++ b/src/pages/[eleccion]/index.astro
@@ -85,7 +85,7 @@ const canonicalPath = `/${eleccion}`;
 ---
 
 <Base title={titulo} description={descripcion} canonical={canonicalPath}>
-  <main id="main-content" class="mx-auto max-w-3xl lg:max-w-6xl">
+  <main id="main-content" class="mx-auto max-w-3xl">
     <header class="masthead">
       <div>
         <h1 class="masthead__dept">Uruguay</h1>

--- a/src/pages/[eleccion]/index.astro
+++ b/src/pages/[eleccion]/index.astro
@@ -14,6 +14,7 @@ import EleccionSelector from '../../components/selectors/EleccionSelector.vue';
 import GranularitySelector from '../../components/selectors/GranularitySelector.vue';
 import Sello from '../../components/ui/Sello.astro';
 import ShareButton from '../../components/share/ShareButton.vue';
+import ThemeToggle from '../../components/ui/ThemeToggle.vue';
 import deptsConfig from '../../config/departments.json';
 
 type DeptEntry = { id: string; label: string; elecciones: string[] };
@@ -90,7 +91,10 @@ const canonicalPath = `/${eleccion}`;
         <h1 class="masthead__dept">Uruguay</h1>
         <p class="masthead__eleccion">{eleccionLabel} — mapa nacional</p>
       </div>
-      <ShareButton client:idle />
+      <div class="masthead__actions">
+        <ThemeToggle client:idle />
+        <ShareButton client:idle />
+      </div>
     </header>
     {preguntaPlebiscito && (
       <p class="pregunta-banner">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,26 @@
   /* Map */
   --color-map-bg:    #F8FAFC;
   --color-sin-datos: #E5E7EB;
+
+  /* ── Epic 23 (rediseño UX): tokens de forma/tipografía/densidad ───────────── */
+  /* Tipografía */
+  --font-display: 'Source Serif 4', Georgia, serif;
+  --font-ui:      'Inter', system-ui, sans-serif;
+  --font-num:     'Source Serif 4', Georgia, serif;
+  --num-feat:     "lnum" 1;
+  /* Radios */
+  --radius:    5px;
+  --radius-sm: 3px;
+  --radius-lg: 10px;
+  /* Sombras */
+  --shadow-sm:    0 1px 2px rgba(40, 34, 22, 0.06);
+  --shadow:       0 4px 16px rgba(40, 34, 22, 0.10);
+  --shadow-lg:    0 18px 50px rgba(40, 34, 22, 0.18);
+  --shadow-sheet: 0 -12px 44px rgba(40, 34, 22, 0.16);
+  /* Densidad / layout */
+  --pad:    16px;
+  --gap:    16px;
+  --rail-w: 384px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -50,6 +70,11 @@
     --color-highlight-border: #4A5C80;
     --color-map-bg:    #1E2638;
     --color-sin-datos: #313C56;
+    /* Epic 23: sombras más densas en oscuro */
+    --shadow-sm:    0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow:       0 6px 22px rgba(0, 0, 0, 0.5);
+    --shadow-lg:    0 22px 60px rgba(0, 0, 0, 0.6);
+    --shadow-sheet: 0 -12px 44px rgba(0, 0, 0, 0.5);
   }
 }
 
@@ -198,3 +223,85 @@ h1, h2, h3 {
   outline: 2px solid var(--color-focus);
   outline-offset: 2px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Epic 23 · Story 23.1 — Primitivos visuales reutilizables (Dirección A · Editorial)
+   Clases globales (no scoped) que portan el look del mockup. Se aplican de a poco
+   por componente en las fases siguientes; son additivas y no afectan nada existente.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Números tabulares/lining */
+.num { font-family: var(--font-num); font-variant-numeric: tabular-nums; }
+
+/* Segmented control — track con píldora activa (reemplaza tabs/botones unidos) */
+.seg {
+  display: inline-flex;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 3px;
+  gap: 2px;
+}
+.seg button {
+  border: none;
+  background: transparent;
+  color: var(--color-ink-muted);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  padding: 6px 13px;
+  border-radius: calc(var(--radius) - 2px);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+}
+.seg button svg { width: 14px; height: 14px; opacity: 0.8; }
+.seg button:hover { color: var(--color-ink); }
+.seg button.on {
+  background: var(--color-card);
+  color: var(--color-ink);
+  box-shadow: var(--shadow-sm);
+}
+.seg button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+.seg button[aria-disabled="true"],
+.seg button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Card — superficie de contenido (rail de resultados, ficha, etc.) */
+.card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Topbar — barra superior sticky con marca (se usa en Fase 2) */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: 56px;
+  padding: 0 var(--pad);
+  background: color-mix(in srgb, var(--color-paper) 86%, transparent);
+  backdrop-filter: saturate(1.3) blur(12px);
+  border-bottom: 1px solid var(--color-border);
+}
+.topbar__brand { display: flex; align-items: center; gap: 11px; min-width: 0; }
+.topbar__mark {
+  width: 30px; height: 30px; flex-shrink: 0;
+  display: grid; place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent); color: #fff;
+  font-family: var(--font-display); font-weight: 700; font-size: 15px;
+  box-shadow: var(--shadow-sm);
+}
+.topbar__spacer { flex: 1; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,31 +2,34 @@
 
 /* ── Design tokens (DESIGN.md) ─────────────────────────────────────────── */
 :root {
+  /* Paleta = Dirección A · Editorial del mockup de Claude Design (papel cálido + tinta + oxblood). */
   /* Surfaces */
-  --color-bg:        #E9E5DC;
-  --color-paper:     #F7F4EE;
+  --color-bg:        #ECE7DD;
+  --color-paper:     #F6F2EA;
   --color-card:      #FFFFFF;
-  --color-surface-1: #F9FAFB;
-  --color-surface-2: #F3F4F6;
+  --color-surface-1: #F1ECE2;
+  --color-surface-2: #EFE9DE;
   /* Borders */
-  --color-border:        #E5E7EB;
-  --color-border-strong: #D1D5DB;
+  --color-border:        #E2DBCC;
+  --color-border-strong: #D0C7B4;
   /* Text */
-  --color-ink:       #1A1916;
-  --color-ink-soft:  #374151;
-  --color-ink-muted: #6B7280;
-  --color-ink-faint: #9CA3AF;
+  --color-ink:       #1C1A16;
+  --color-ink-soft:  #4C473D;
+  --color-ink-muted: #857E6F;
+  --color-ink-faint: #ABA493;
   /* Accent / focus */
-  --color-accent:    #8A1C1C;
-  --color-focus:     #6366F1;
+  --color-accent:      #8A1C1C;
+  --color-accent-soft: #F0E2DC;
+  --color-focus:       #8A1C1C;
+  --color-good:        #2D7D3E;
   /* Interactive states */
-  --color-btn-active-bg: #111827;
-  --color-btn-active-fg: #FFFFFF;
-  --color-highlight:        #EFF6FF;
-  --color-highlight-border: #93C5FD;
+  --color-btn-active-bg: #1C1A16;
+  --color-btn-active-fg: #F6F2EA;
+  --color-highlight:        #F0E2DC;
+  --color-highlight-border: #D0C7B4;
   /* Map */
-  --color-map-bg:    #F8FAFC;
-  --color-sin-datos: #E5E7EB;
+  --color-map-bg:    #F8F4EC;
+  --color-sin-datos: #E2DBCC;
 
   /* ── Epic 23 (rediseño UX): tokens de forma/tipografía/densidad ───────────── */
   /* Tipografía */
@@ -51,25 +54,28 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg:        #0E1320;
-    --color-paper:     #151B2B;
-    --color-card:      #28324A;
-    --color-surface-1: #1E2638;
-    --color-surface-2: #252F45;
-    --color-border:        #5F6E92;
-    --color-border-strong: #6E7FA5;
-    --color-ink:       #E8ECF6;
-    --color-ink-soft:  #C1CAE0;
-    --color-ink-muted: #93A0BC;
-    --color-ink-faint: #68779A;
-    --color-accent:    #E0A6A6;
-    --color-focus:     #E0A6A6;
-    --color-btn-active-bg: #E8ECF6;
-    --color-btn-active-fg: #151B2B;
-    --color-highlight:        #252F45;
-    --color-highlight-border: #4A5C80;
-    --color-map-bg:    #1E2638;
-    --color-sin-datos: #313C56;
+    /* Dark = Dirección A · Editorial del mockup (oscuro CÁLIDO, no navy). */
+    --color-bg:        #131210;
+    --color-paper:     #1C1A16;
+    --color-card:      #25221B;
+    --color-surface-1: #201D17;
+    --color-surface-2: #232019;
+    --color-border:        #383328;
+    --color-border-strong: #4D4738;
+    --color-ink:       #F1ECE0;
+    --color-ink-soft:  #C9C2B1;
+    --color-ink-muted: #908979;
+    --color-ink-faint: #6E6857;
+    --color-accent:      #E6AEAE;
+    --color-accent-soft: #36241F;
+    --color-focus:       #E6AEAE;
+    --color-good:        #5FBE73;
+    --color-btn-active-bg: #F1ECE0;
+    --color-btn-active-fg: #1C1A16;
+    --color-highlight:        #36241F;
+    --color-highlight-border: #4D4738;
+    --color-map-bg:    #1A1813;
+    --color-sin-datos: #383328;
     /* Epic 23: sombras más densas en oscuro */
     --shadow-sm:    0 1px 2px rgba(0, 0, 0, 0.4);
     --shadow:       0 6px 22px rgba(0, 0, 0, 0.5);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,8 +52,10 @@
   --rail-w: 384px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
+/* Dark (Epic 23 · Story 23.5) — se activa por data-theme="dark" en <html>, que pone el
+   script anti-flash de Base.astro: toggle manual o, en modo "auto", resuelto desde
+   prefers-color-scheme. El app requiere JS para el mapa, así que no hay fallback no-JS. */
+:root[data-theme="dark"] {
     /* Dark = Dirección A · Editorial del mockup (oscuro CÁLIDO, no navy). */
     --color-bg:        #131210;
     --color-paper:     #1C1A16;
@@ -81,7 +83,6 @@
     --shadow:       0 6px 22px rgba(0, 0, 0, 0.5);
     --shadow-lg:    0 22px 60px rgba(0, 0, 0, 0.6);
     --shadow-sheet: 0 -12px 44px rgba(0, 0, 0, 0.5);
-  }
 }
 
 html {
@@ -114,6 +115,12 @@ h1, h2, h3 {
   font-size: 0.8125rem;
   color: var(--color-ink-soft);
   margin: 0.125rem 0 0;
+}
+.masthead__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
 }
 
 /* ── Department nav ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
Epic 23 · Rediseño UX a partir del handoff de Claude Design (Dirección A · Editorial). **Draft / WIP** — re-skinea sin remover funciones.

## Hecho (verificado en browser + `npm run check` 0 errores)
- **23.1 base visual** — tokens de forma + primitivos `.seg`/`.card`/`.topbar`/`.num`; selectores de nivel/granularidad como segmented controls.
- **23.1 color** — paleta exacta del mockup (papel cálido + **dark cálido** marrón en vez de navy).
- **23.2 layout** — workspace **2-columnas** en desktop (≥1024px): mapa héroe + rail de resultados sticky; 1 columna en mobile.
- **23.5 dark toggle** — manual claro/oscuro/auto en el masthead (anti-flash, persistido).
- **23.3 rail** — ResultadoGlobal como card.

## Pendiente
- **23.4** mapa: badge de leyenda overlay + tooltip on-brand.
- **23.6** timeline con nodos conectados.

Plan completo y estado en `docs/superpowers/plans/2026-06-04-epic-23-ux-redesign.md`.

> CI: el check de GH Actions falla por cuota LFS (no es código); el gate real es el build de Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)