### PR TITLE
fix(api): caché del edge servía datos viejos (immutable + s-maxage 1 año en datos mutables)

### DIFF
--- a/scripts/vercel-cors-headers.mjs
+++ b/scripts/vercel-cors-headers.mjs
@@ -27,7 +27,11 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 
-const CACHE = 'public, max-age=3600, s-maxage=31536000, immutable';
+// Datos MUTABLES en URL estable (se actualizan en cada deploy): NO usar `immutable` ni s-maxage
+// largo — eso fija la respuesta vieja en el edge para siempre y un deploy nuevo no la purga
+// (bug: la API quedaba sirviendo datos viejos pese a redeploy). Edge fresco 60s + stale-while-
+// revalidate para refrescar en background → un deploy se ve en ~1 min sin perder performance CDN.
+const CACHE = 'public, max-age=0, s-maxage=60, stale-while-revalidate=86400';
 
 // Build Output API: `headers` es un objeto plano (no el array {key,value} de vercel.json).
 const HEADER_ROUTES = [


### PR DESCRIPTION
## Síntoma
Tras mergear #56, la API pública seguía sirviendo **candidatos/dumps/openapi viejos** pese a que el deploy (commit `0872d74`) construyó los nuevos — confirmado en los **build logs** (`[gate:api] ... 24/24 ... contrato v1 OK`) y que la deployment está Ready y aliaseada al dominio.

## Causa raíz
`/api/v1/**` y `/data/**` (datos **mutables** en URL estable) se servían con `Cache-Control: public, max-age=3600, s-maxage=31536000, immutable`. `immutable` + s-maxage de **1 año** fija la respuesta en el edge y **un deploy nuevo no la purga**. Cada path que se pidió de prod **antes** de su deploy quedó clavado en la versión vieja; los que se pidieron por primera vez **después** (p.ej. `/data` de municipales) se vieron frescos. Eso explica exactamente el patrón observado.

## Fix
`public, max-age=0, s-maxage=60, stale-while-revalidate=86400` — navegador revalida siempre, edge fresco 60s + SWR refresca en background. Un deploy se ve en ~1 min sin perder performance. Los assets hasheados (`/_astro/*`) no pasan por estas rutas (los cachea Astro con su propio immutable, correcto para URLs con hash).

> Nota: las entradas ya clavadas con el header viejo pueden requerir un **Purge Cache** en el dashboard para vaciarse de inmediato; de ahí en más el header nuevo evita que vuelva a pasar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF