### PR TITLE
fix(ux): rótulos del selector según el nivel terminal (no decir "lista" donde no hay)

### DIFF
--- a/src/components/selectors/OpcionAccordion.test.ts
+++ b/src/components/selectors/OpcionAccordion.test.ts
@@ -189,3 +189,43 @@ describe('OpcionAccordion — vista nacional CON catálogo de hoja (feature naci
     expect(wrapper.text()).toContain('UNIDAD PARA LA ESPERANZA');
   });
 });
+
+/**
+ * Prolijidad: el rótulo refleja el TERMINAL de la contienda. Una contienda de intendente
+ * (lema → candidato) NO debe decir "lista" en ningún lado visible.
+ */
+describe('OpcionAccordion — rótulo terminal-aware (no dice "lista" si no hay listas)', () => {
+  const CAT_INTENDENTE = {
+    eleccionId: 'departamentales-2025',
+    departamento: 'salto',
+    contiendas: [{
+      contienda: 'intendente',
+      niveles: ['lema', 'candidato'],
+      nodos: [{ id: 'pn', nivel: 'lema', etiqueta: 'Partido Nacional', partidoId: 'pn' }],
+      opciones: [{ clase: 'candidato', id: 'int-pn-x', candidato: 'Fulano Mengano', lemaId: 'pn', contienda: 'intendente' }],
+    }],
+  };
+  beforeEach(() => {
+    $context.set({ eleccion: 'departamentales-2025', departamento: 'salto' });
+    $selection.set({ zona: null, opcion: null, contienda: null, seleccion: [], modo: null, gnivel: null });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/_manifest.json')) return new Response(JSON.stringify({ 'departamentales-2025': { salto: ['catalogo'] } }), { status: 200 });
+      if (url.includes('/catalogo.json')) return new Response(JSON.stringify(CAT_INTENDENTE), { status: 200 });
+      return new Response(JSON.stringify({ zonas: [] }), { status: 200 });
+    }));
+  });
+
+  it('intendente: header dice "candidato / partido" y el chip "N candidato(s)", nunca "lista"', async () => {
+    const wrapper = mount(OpcionAccordion, { props: { eleccion: 'departamentales-2025', departamento: 'salto' } });
+    await flushPromises();
+
+    expect(wrapper.find('.acc__toggle-lbl').text()).toBe('Filtrar por candidato / partido');
+
+    // Seleccionar el candidato del lema → chip habla de candidatos, no de listas.
+    const cb = wrapper.findAll('button').find((b) => b.attributes('aria-label')?.startsWith('Seleccionar todas'));
+    await cb!.trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.acc__chip--sel').text()).toBe('1 candidato seleccionado');
+    expect(wrapper.text().toLowerCase()).not.toContain('lista');
+  });
+});

--- a/src/components/selectors/OpcionAccordion.vue
+++ b/src/components/selectors/OpcionAccordion.vue
@@ -151,15 +151,27 @@ const esPlano = computed(() => (contienda.value?.niveles.length ?? 2) <= 1);
 // Rotularlas "listas" confunde (lista y partido no es lo mismo); acá se nombran bien.
 const esBinariaPlano = computed(() => (contienda.value?.opciones ?? []).some((o) => o.clase === 'binaria'));
 const esBalotaje = props.eleccion.startsWith('balotaje');
-/** Sustantivo (+ género) del nivel terminal del selector, según modo/elección. */
+/** Sustantivo (+género) del nivel TERMINAL de la contienda activa = lo más fino que se filtra.
+ *  No toda contienda termina en "lista": intendente → candidato, municipio → alcalde, plebiscito → opción. */
+const NOUN_TERMINAL: Record<string, { sing: string; plur: string; genero: 'f' | 'm' }> = {
+  hoja:      { sing: 'lista',     plur: 'listas',     genero: 'f' },
+  candidato: { sing: 'candidato', plur: 'candidatos', genero: 'm' },
+  alcalde:   { sing: 'alcalde',   plur: 'alcaldes',   genero: 'm' },
+  binaria:   { sing: 'opción',    plur: 'opciones',   genero: 'f' },
+};
+const terminoTerminal = computed<{ sing: string; plur: string; genero: 'f' | 'm' }>(
+  () => NOUN_TERMINAL[nivelHoja.value] ?? { sing: 'opción', plur: 'opciones', genero: 'f' });
+/** Sustantivo de las opciones. ÁRBOL = el terminal de la contienda (lista/candidato/alcalde);
+ *  PLANO = partido (vista nacional) / candidato (balotaje) / opción (plebiscito). Nunca "lista" si no la hay. */
 const sustantivo = computed<{ sing: string; plur: string; genero: 'f' | 'm' }>(() => {
-  if (!esPlano.value) return { sing: 'lista', plur: 'listas', genero: 'f' };
+  if (!esPlano.value) return terminoTerminal.value;
   if (esBinariaPlano.value) return { sing: 'opción', plur: 'opciones', genero: 'f' };
   if (esBalotaje) return { sing: 'candidato', plur: 'candidatos', genero: 'm' };
   return { sing: 'partido', plur: 'partidos', genero: 'm' };
 });
-/** Título del header del control. En el árbol hay listas y partidos; en plano, solo el sustantivo. */
-const tituloFiltro = computed(() => (esPlano.value ? `Filtrar por ${sustantivo.value.sing}` : 'Filtrar por lista / partido'));
+/** Título del control. ÁRBOL: "{terminal} / partido" (lista/candidato/alcalde + partido); PLANO: el sustantivo. */
+const tituloFiltro = computed(() =>
+  esPlano.value ? `Filtrar por ${sustantivo.value.sing}` : `Filtrar por ${terminoTerminal.value.sing} / partido`);
 /** Texto del chip de selección, con concordancia de género. */
 const chipSeleccion = computed(() => {
   const n = seleccion.value.size;
@@ -435,9 +447,9 @@ const flagLema  = (l: NodoOpcion): string | null => resolveParty(l.etiqueta).fla
           v-model="busqueda"
           class="acc__busqueda"
           type="search"
-          :inputmode="nivelHoja === 'candidato' ? 'text' : 'numeric'"
-          :placeholder="nivelHoja === 'candidato' ? 'Buscar candidato…' : 'Buscar lista por número…'"
-          :aria-label="nivelHoja === 'candidato' ? 'Buscar candidato' : 'Buscar lista por número'"
+          :inputmode="nivelHoja === 'hoja' ? 'numeric' : 'text'"
+          :placeholder="nivelHoja === 'hoja' ? 'Buscar lista por número…' : `Buscar ${terminoTerminal.sing}…`"
+          :aria-label="nivelHoja === 'hoja' ? 'Buscar lista por número' : `Buscar ${terminoTerminal.sing}`"
         />
         <select v-model="filtroPartido" class="acc__filtro" aria-label="Filtrar por partido">
           <option value="">Todos los partidos</option>


### PR DESCRIPTION
El header y el chip del selector ahora reflejan el **nivel terminal de la contienda activa** en vez de un "lista" hardcodeado:

- **intendente** → "Filtrar por candidato / partido", chip "N candidatos", buscador "Buscar candidato".
- **municipio** → alcalde · **junta/odd/odn/nacionales/internas** → lista · **plebiscito/balotaje** (plano) → opción/candidato.
- Vista nacional plana → "partido".

El árbol con hojas reales sigue diciendo "lista / partido". Verificado en browser (departamentales/salto · Intendente → 0 ocurrencias de "lista" en el panel). Tests 78/78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)