### PR TITLE
chore(sweep): harness configurable + audit-ganador consciente de consolidados

### DIFF
--- a/scripts/audit-ganador.py
+++ b/scripts/audit-ganador.py
@@ -30,6 +30,17 @@ for cat_path in glob.glob(os.path.join(DATA, '*', '*', 'catalogo.json')):
     for z in votes['zonas']:
         for o in z.get('porOpcion', []):
             baseTot[o['opcionId']] += o.get('votos', 0)
+    # Para niveles localidad/barrio/municipio el cliente colorea con el consolidado hoja-{nivel}.json
+    # (ensureHojaGeoConsolidado), NO con hoja/{lema}.json. Incluir sus opcionIds con votos evita
+    # falsos negativos (p.ej. municipales municipio: las hojas viven en hoja-municipio.json).
+    consolidadoIds = set()
+    for nivel in ('municipio', 'localidad', 'barrio'):
+        cons = load(os.path.join(d, f'hoja-{nivel}.json'))
+        if cons:
+            for z in cons.get('zonas', []):
+                for o in z.get('porOpcion', []):
+                    if o.get('votos', 0) > 0:
+                        consolidadoIds.add(o['opcionId'])
     for c in cat.get('contiendas', []):
         cont = c['contienda']
         niveles = c.get('niveles', [])
@@ -57,6 +68,8 @@ for cat_path in glob.glob(os.path.join(DATA, '*', '*', 'catalogo.json')):
                     if baseTot.get(s, 0) > 0:
                         paintable = True
                         break
+            if not paintable and (sel & consolidadoIds):
+                paintable = True  # colorea vía consolidado hoja-{nivel}.json (localidad/barrio/municipio)
             revisados += 1
             if not paintable:
                 inter = len(sel & shard_ids)

--- a/scripts/smoke-sweep.mjs
+++ b/scripts/smoke-sweep.mjs
@@ -13,7 +13,8 @@ import path from 'node:path';
 const BASE = process.env.SWEEP_BASE || 'http://localhost:4322';
 const DATA = 'public/data';
 const MAX_DEPTOS = Number(process.argv[2] ?? 6);   // por elección, además de montevideo
-const CONCURRENCY = 5;
+const CONCURRENCY = Number(process.env.SWEEP_CONCURRENCY ?? 5);
+const NAV_TIMEOUT = Number(process.env.SWEEP_TIMEOUT ?? 20000);
 
 const readJSON = (p) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; } };
 
@@ -110,7 +111,7 @@ async function worker(wid) {
     page.on('response', onResp);
     let navOk = true;
     try {
-      await page.goto(BASE + job.url, { waitUntil: 'load', timeout: 20000 });
+      await page.goto(BASE + job.url, { waitUntil: 'load', timeout: NAV_TIMEOUT });
       await page.waitForTimeout(1600); // hidratación de islas (client:idle/load) + fetches async
     } catch (e) {
       navOk = false;


### PR DESCRIPTION
Endurece los sweeps de errores para que la señal sea limpia y confiable:

- **smoke-sweep.mjs**: `SWEEP_CONCURRENCY` / `SWEEP_TIMEOUT` por env. A concurrencia alta el dev server (Vite, on-demand) timeouteaba páginas → falsos positivos; bajar concurrencia + subir timeout da 0 falsos.
- **audit-ganador.py**: ahora considera los consolidados `hoja-{nivel}.json` (localidad/barrio/municipio) que el cliente usa para colorear. Antes reportaba 291 falsos negativos en `municipales municipio` (las hojas viven en `hoja-municipio.json`, no en `hoja/{lema}.json`). Verificado en browser que seleccionar una lista de municipio SÍ colorea. Ahora → **0**.

Sweep completo tras esto: smoke 1256 URLs 0 errores · vitest 78/78 · gates OK · audit-ganador 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)